### PR TITLE
Missing dependency updates related to java 11 migration and bumps from dependabot

### DIFF
--- a/bitrepository-alarm-service/pom.xml
+++ b/bitrepository-alarm-service/pom.xml
@@ -46,9 +46,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitrepository.reference</groupId>

--- a/bitrepository-audit-trail-service/pom.xml
+++ b/bitrepository-audit-trail-service/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>bitrepository-parent</artifactId>
@@ -43,9 +44,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs.version}</version>
     </dependency>
     <dependency>
       <groupId>javax</groupId>

--- a/bitrepository-core/pom.xml
+++ b/bitrepository-core/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bitrepository.reference</groupId>
@@ -24,7 +25,7 @@
       <groupId>org.bitrepository.repository-settings</groupId>
       <artifactId>bitrepository-repository-settings-java</artifactId>
       <version>${repository.settings.version}</version>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>org.bitrepository</groupId>
       <artifactId>bitrepository-message-xml-xsd</artifactId>
@@ -43,17 +44,17 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.12</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.65</version>
+      <version>1.70</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15on</artifactId>
-      <version>1.65</version>
+      <version>1.70</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -74,7 +75,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>11.0.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bitrepository-integration/src/main/resources/quickstart/scripts/quickstart.sh
+++ b/bitrepository-integration/src/main/resources/quickstart/scripts/quickstart.sh
@@ -38,7 +38,7 @@ export CATALINA_PID="${quickstartdir}/tomcat/pid.tomcat"
 # Function that starts the quickstart components
 #
 do_start() {
-    export CATALINA_OPTS="-Xms256m -Xmx1028m -XX:PermSize=256m -XX:MaxPermSize=256m"
+    export CATALINA_OPTS="-Xms256m -Xmx1028m"
     ${quickstartdir}/file1pillar/bin/pillar.sh start
     ${quickstartdir}/file2pillar/bin/pillar.sh start
     ${quickstartdir}/checksumpillar/bin/pillar.sh start

--- a/bitrepository-integrity-service/pom.xml
+++ b/bitrepository-integrity-service/pom.xml
@@ -47,9 +47,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitrepository.reference</groupId>

--- a/bitrepository-monitoring-service/pom.xml
+++ b/bitrepository-monitoring-service/pom.xml
@@ -46,9 +46,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs.version}</version>
     </dependency>
     <!-- provided scope -->
     <dependency>

--- a/bitrepository-service/pom.xml
+++ b/bitrepository-service/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.14</version>
+      <version>42.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>

--- a/bitrepository-webclient/pom.xml
+++ b/bitrepository-webclient/pom.xml
@@ -44,9 +44,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitrepository.reference</groupId>
@@ -90,8 +90,5 @@
     </plugins>
   </build>
 
-  <properties>
-    <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
-  </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
       <organizationUrl>http://en.statsbiblioteket.dk</organizationUrl>
     </developer>
     <developer>
-      <name>Kim Teglgaard Christensen   </name>
+      <name>Kim Teglgaard Christensen</name>
       <email>ktc@statsbiblioteket.dk</email>
       <organization>The Danish State and University Library</organization>
       <organizationUrl>http://en.statsbiblioteket.dk</organizationUrl>
@@ -126,30 +126,35 @@
     </dependency>
     <!-- Updating org.jvnet jaxb2 dependencies to 0.12.0 causes problems for the jaxb2-maven-plugin
           when trying to use toString, hashCode etc.
-          (sort of described here: https://github.com/highsource/jaxb2-basics/issues/95) -->
+          (sort of described here: https://github.com/highsource/jaxb2-basics/issues/95)
+         The project seems to no longer be maintained..
+    -->
     <dependency>
       <groupId>org.jvnet.jaxb2_commons</groupId>
       <artifactId>jaxb2-basics-runtime</artifactId>
       <version>0.11.1</version>
     </dependency>
-    <!-- javax.xml.bind should be swapped for jakarta.xml.bind once a JAXB-plugin actually
-          supports the new jakarta dependencies without going through weird hoops to get things working. -->
+    <!-- Below jakarta/jaxb dependencies are necessary for jaxb-xml with java 11-->
+    <!-- https://mvnrepository.com/artifact/javax.xml.bind/javax.xml.bind-api -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/jakarta.activation/jakarta.activation-api -->
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.3.1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>1.2.2</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>3.0.1</version>
+      <version>2.3.6</version>
       <scope>runtime</scope>
     </dependency>
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -480,8 +485,8 @@
     <derby.version>10.14.2.0</derby.version>
     <activemq.version>5.15.13</activemq.version>
     <cxf.version>3.3.6</cxf.version>
-    <jackson.version>2.11.0</jackson.version>
-    <javax.ws.rs.version>2.1.1</javax.ws.rs.version>
+    <jackson.version>2.12.5</jackson.version>
+    <jakarta.ws.rs.version>2.1.6</jakarta.ws.rs.version>
     <javaee.web.version>8.0.1</javaee.web.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Updated non-jakartified dependencies to work in java 11 and removed some old ignored stuff related to tomcat