### PR TITLE
BITMAG-973 & BITMAG-978: small commandline fixes for use of -p argument

### DIFF
--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
@@ -145,11 +145,6 @@ public abstract class CommandLineClient {
         Option fileIDOption = new Option(Constants.FILE_ID_ARG, Constants.HAS_ARGUMENT, "The id for the file to perform the operation on.");
         fileIDOption.setRequired(isFileIDArgumentRequired());
         cmdHandler.addOption(fileIDOption);
-
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
-        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
-        cmdHandler.addOption(pillarOption);
     }
 
     /**

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/Constants.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/Constants.java
@@ -92,7 +92,11 @@ public class Constants {
     /**
      * The argument for the location of the results.
      */
-    public static final String LOCATION = "l";
+    public static final String LOCATION_ARG = "l";
+
+    public static final String PILLAR_DESC =
+            "The id of the pillar where the operation should be performed. " +
+                    "If undefined the operation is performed on all pillars.";
 
     public static final int EXIT_SUCCESS = 0;
     public static final int EXIT_ARGUMENT_FAILURE = 1;

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/DeleteFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/DeleteFileCmd.java
@@ -73,6 +73,11 @@ public class DeleteFileCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
+                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        cmdHandler.addOption(pillarOption);
+
         Option checksumOption = new Option(Constants.CHECKSUM_ARG, Constants.HAS_ARGUMENT,
                 "[OPTIONAL] The checksum of the file to be deleted.");
         checksumOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/DeleteFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/DeleteFileCmd.java
@@ -73,9 +73,8 @@ public class DeleteFileCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
-        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, Constants.PILLAR_DESC);
+        pillarOption.setRequired(Constants.ARGUMENT_IS_REQUIRED);
         cmdHandler.addOption(pillarOption);
 
         Option checksumOption = new Option(Constants.CHECKSUM_ARG, Constants.HAS_ARGUMENT,

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetChecksumsCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetChecksumsCmd.java
@@ -72,6 +72,11 @@ public class GetChecksumsCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
+                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        cmdHandler.addOption(pillarOption);
+
         Option checksumTypeOption = new Option(Constants.REQUEST_CHECKSUM_TYPE_ARG, Constants.HAS_ARGUMENT,
                 "[OPTIONAL] The algorithm of checksum to request in the response from the pillars. "
                         + "If no such argument is given, then the default from settings is retrieved.");

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetChecksumsCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetChecksumsCmd.java
@@ -72,8 +72,8 @@ public class GetChecksumsCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT,
+                "[OPTIONAL] " + Constants.PILLAR_DESC);
         pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(pillarOption);
 

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileCmd.java
@@ -74,6 +74,12 @@ public class GetFileCmd extends CommandLineClient {
     @Override
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
+
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
+                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        cmdHandler.addOption(pillarOption);
+
         Option checksumOption = new Option(Constants.LOCATION, Constants.HAS_ARGUMENT,
                 "[OPTIONAL] The location where the file should be placed (either total path or directory). "
                         + "If no argument, then the file is placed in the directory where the script is located.");

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileCmd.java
@@ -75,12 +75,12 @@ public class GetFileCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT,
+                "[OPTIONAL] " + Constants.PILLAR_DESC);
         pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(pillarOption);
 
-        Option checksumOption = new Option(Constants.LOCATION, Constants.HAS_ARGUMENT,
+        Option checksumOption = new Option(Constants.LOCATION_ARG, Constants.HAS_ARGUMENT,
                 "[OPTIONAL] The location where the file should be placed (either total path or directory). "
                         + "If no argument, then the file is placed in the directory where the script is located.");
         checksumOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
@@ -134,8 +134,8 @@ public class GetFileCmd extends CommandLineClient {
     private void downloadFile() {
         output.debug("Downloading the file.");
         File outputFile;
-        if (cmdHandler.hasOption(Constants.LOCATION)) {
-            File location = new File(cmdHandler.getOptionValue(Constants.LOCATION));
+        if (cmdHandler.hasOption(Constants.LOCATION_ARG)) {
+            File location = new File(cmdHandler.getOptionValue(Constants.LOCATION_ARG));
             if (location.isDirectory()) {
                 outputFile = new File(location, cmdHandler.getOptionValue(Constants.FILE_ID_ARG));
             } else {

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileIDsCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileIDsCmd.java
@@ -70,8 +70,8 @@ public class GetFileIDsCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT,
+                "[OPTIONAL] " + Constants.PILLAR_DESC);
         pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(pillarOption);
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileIDsCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/GetFileIDsCmd.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.commandline;
 
+import org.apache.commons.cli.Option;
 import org.bitrepository.access.AccessComponentFactory;
 import org.bitrepository.access.getfileids.GetFileIDsClient;
 import org.bitrepository.commandline.clients.PagingGetFileIDsClient;
@@ -63,6 +64,16 @@ public class GetFileIDsCmd extends CommandLineClient {
         output.debug("Instantiation GetFileID paging client.");
         int pageSize = SettingsUtils.getMaxClientPageSize();
         pagingClient = new PagingGetFileIDsClient(client, getTimeout(), pageSize, outputFormatter, output);
+    }
+
+    @Override
+    protected void createOptionsForCmdArgumentHandler() {
+        super.createOptionsForCmdArgumentHandler();
+
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
+                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        cmdHandler.addOption(pillarOption);
     }
 
     @Override

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/ReplaceFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/ReplaceFileCmd.java
@@ -34,6 +34,7 @@ import org.bitrepository.modify.replacefile.ReplaceFileClient;
 import java.net.URL;
 
 import static org.bitrepository.commandline.Constants.ARGUMENT_IS_NOT_REQUIRED;
+import static org.bitrepository.commandline.Constants.ARGUMENT_IS_REQUIRED;
 import static org.bitrepository.commandline.Constants.CHECKSUM_ARG;
 import static org.bitrepository.commandline.Constants.DELETE_FILE_ARG;
 import static org.bitrepository.commandline.Constants.EXIT_ARGUMENT_FAILURE;
@@ -84,22 +85,26 @@ public class ReplaceFileCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
-        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
-                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
-        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, Constants.PILLAR_DESC);
+        pillarOption.setRequired(Constants.ARGUMENT_IS_REQUIRED);
         cmdHandler.addOption(pillarOption);
 
-        Option checksumOption = new Option(CHECKSUM_ARG, HAS_ARGUMENT, "[OPTIONAL] The checksum of the file to be replaced.");
+        Option checksumOption = new Option(CHECKSUM_ARG, HAS_ARGUMENT,
+                "The checksum of the file to be replaced.");
+        // Setting can allow -C to be non-required, so set it as so.
         checksumOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(checksumOption);
+
         Option fileOption = new Option(FILE_ARG, HAS_ARGUMENT,
                 "The path to the new file for the replacement. Required unless using the URL argument.");
         fileOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(fileOption);
+
         Option urlOption = new Option(URL_ARG, HAS_ARGUMENT,
                 "The URL for the file to be retrieved. Is required, unless the actual file is given.");
         urlOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(urlOption);
+
         Option replaceChecksumOption = new Option(REPLACE_CHECKSUM_ARG, HAS_ARGUMENT,
                 "The checksum for the file to replace with. Required when using the URL argument.");
         replaceChecksumOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
@@ -109,8 +114,10 @@ public class ReplaceFileCmd extends CommandLineClient {
                 "[OPTIONAL] The algorithm of checksum to request in the response from the pillars.");
         checksumTypeOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(checksumTypeOption);
+
         Option checksumSaltOption = new Option(REQUEST_CHECKSUM_SALT_ARG, HAS_ARGUMENT,
-                "[OPTIONAL] The salt of checksum to request in the response. Requires the ChecksumType argument.");
+                "[OPTIONAL] The salt of checksum to request in the response. " +
+                        "Requires the ChecksumType argument.");
         checksumSaltOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(checksumSaltOption);
 

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/ReplaceFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/ReplaceFileCmd.java
@@ -84,6 +84,11 @@ public class ReplaceFileCmd extends CommandLineClient {
     protected void createOptionsForCmdArgumentHandler() {
         super.createOptionsForCmdArgumentHandler();
 
+        Option pillarOption = new Option(Constants.PILLAR_ARG, Constants.HAS_ARGUMENT, "[OPTIONAL] The id of the " +
+                "pillar where the operation should be performed. If undefined the operation is performed on all pillars.");
+        pillarOption.setRequired(Constants.ARGUMENT_IS_NOT_REQUIRED);
+        cmdHandler.addOption(pillarOption);
+
         Option checksumOption = new Option(CHECKSUM_ARG, HAS_ARGUMENT, "[OPTIONAL] The checksum of the file to be replaced.");
         checksumOption.setRequired(ARGUMENT_IS_NOT_REQUIRED);
         cmdHandler.addOption(checksumOption);

--- a/bitrepository-client/src/test/java/org/bitrepository/commandline/PutFileCmdTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/commandline/PutFileCmdTest.java
@@ -72,32 +72,6 @@ public class PutFileCmdTest extends DefaultFixtureClientTest {
         new PutFileCmd(args);
     }
 
-    @Test(groups = { "regressiontest" })
-    public void specificPillarArgumentTest() throws Exception {
-        addDescription("Test argument for a specific pillar");
-        String[] args = new String[]{"-s" + SETTINGS_DIR, 
-                "-k" + KEY_FILE,
-                "-u" + DEFAULT_UPLOAD_FILE_ADDRESS, 
-                "-C" + DEFAULT_CHECKSUM,
-                "-c" + DEFAULT_COLLECTION_ID,
-                "-p" + PILLAR1_ID,
-                "-i" + DEFAULT_FILE_ID};
-        new PutFileCmd(args);
-    }
-
-    @Test(groups = { "regressiontest" }, expectedExceptions = IllegalArgumentException.class)
-    public void unknownPillarArgumentTest() throws Exception {
-        addDescription("Testing against a non-existing pillar id -> Should fail");
-        String[] args = new String[]{"-s" + SETTINGS_DIR, 
-                "-k" + KEY_FILE,
-                "-u" + DEFAULT_UPLOAD_FILE_ADDRESS, 
-                "-C" + DEFAULT_CHECKSUM,
-                "-c" + DEFAULT_COLLECTION_ID,
-                "-p" + "Random" + (new Date()).getTime() + "pillar",
-                "-i" + DEFAULT_FILE_ID};
-        new PutFileCmd(args);
-    }
-
     @Test(groups = { "regressiontest" }, expectedExceptions = IllegalArgumentException.class)
     public void missingFileOrURLArgumentTest() throws Exception {
         addDescription("Tests the scenario, where no arguments for file or url is given.");


### PR DESCRIPTION
BITMAG-973 | Putfile client should not use -p argument
BITMAG-978 | Deletefile. and replacefile commandline clients tells that -p is optional, it isn't