### PR TITLE
Added UNIQUE constraint on auditdb actor_name as suggested in issue.

### DIFF
--- a/bitrepository-service/src/main/resources/sql/derby/auditContributorDBCreation.sql
+++ b/bitrepository-service/src/main/resources/sql/derby/auditContributorDBCreation.sql
@@ -65,7 +65,7 @@ create index fileindex on file ( fileid, collectionid );
 create table actor (
     actor_guid bigint not null generated always as identity primary key,
                                     -- The guid for the actor.
-    actor_name varchar(255)         -- The name of the actor.
+    actor_name varchar(255) unique  -- The name of the actor.
 );
 
 create index actorindex on actor ( actor_name );

--- a/bitrepository-service/src/main/resources/sql/postgres/auditContributorDBCreation.sql
+++ b/bitrepository-service/src/main/resources/sql/postgres/auditContributorDBCreation.sql
@@ -61,7 +61,7 @@ CREATE INDEX fileindex ON file ( fileid, collectionid );
 --*************************************************************************--
 CREATE TABLE actor (
     actor_guid SERIAL PRIMARY KEY,  -- The guid for the actor.
-    actor_name VARCHAR(255)         -- The name of the actor.
+    actor_name VARCHAR(255) UNIQUE  -- The name of the actor.
 );
 
 CREATE INDEX actorindex ON actor ( actor_name );


### PR DESCRIPTION
So the issue description suggests that this synchronized method snippet for extracting `actor_guid` from the db gets called twice for the same actor with the second run starting before the first has finished inserting the actor into the table.  This results in two `actor` entries with the same `actor_name` but different `actor_guid`...
```
Long guid = DatabaseUtils.selectLongValue(dbConnector, sqlRetrieve, actorName);
if (guid == null) {
    log.debug("Inserting actor '" + actorName + "' into the actor table.");
    String sqlInsert = "INSERT INTO " + ACTOR_TABLE + " ( " + ACTOR_NAME + " ) VALUES ( ? )";
    DatabaseUtils.executeStatement(dbConnector, sqlInsert, actorName);

    guid = DatabaseUtils.selectLongValue(dbConnector, sqlRetrieve, actorName);
}
return guid;
```
I don't understand why this would be specific to only checksum-pillars, but this might've just been a coincidental observation.

I made the suggested solution of just adding a unique constraint on actor_name, which I guess would have the db throw an error on second insertion if it were to happen again, but at least that would be a more meaningful place to throw an error instead of on retrieval.

Unless I'm misunderstanding what is actually happening, we should at some point look into how this synchronized block could even be executed like that to fix the actual problem.