### PR TITLE
BITMAG-1077

### DIFF
--- a/bitrepository-audit-trail-service/src/main/java/org/bitrepository/audittrails/preserver/LocalAuditTrailPreserver.java
+++ b/bitrepository-audit-trail-service/src/main/java/org/bitrepository/audittrails/preserver/LocalAuditTrailPreserver.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.audittrails.preserver;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.audittrails.store.AuditTrailStore;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
@@ -161,7 +162,11 @@ public class LocalAuditTrailPreserver implements AuditTrailPreserver {
         ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
         res.setCalculationTimestamp(CalendarUtils.getNow());
         res.setChecksumSpec(csSpec);
-        res.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            res.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        } catch (DecoderException e) {
+            log.error(e.getMessage());
+        }
 
         return res;
     }

--- a/bitrepository-audit-trail-service/src/main/java/org/bitrepository/audittrails/preserver/LocalAuditTrailPreserver.java
+++ b/bitrepository-audit-trail-service/src/main/java/org/bitrepository/audittrails/preserver/LocalAuditTrailPreserver.java
@@ -149,24 +149,22 @@ public class LocalAuditTrailPreserver implements AuditTrailPreserver {
             throw new CoordinationLayerException("Cannot perform the preservation of audit trails.", e);
         } catch (OperationFailedException e) {
             throw new CoordinationLayerException("Failed to put the packed audit trails.", e);
+        } catch (DecoderException e) {
+            throw new CoordinationLayerException("Failed to encode the checksum.", e);
         }
     }
 
     /**
      * Helper method to make a checksum for the PutFile call.
      */
-    private ChecksumDataForFileTYPE getValidationChecksumDataForFile(File file) {
+    private ChecksumDataForFileTYPE getValidationChecksumDataForFile(File file) throws DecoderException {
         ChecksumSpecTYPE csSpec = ChecksumUtils.getDefault(settings);
         String checksum = ChecksumUtils.generateChecksum(file, csSpec);
 
         ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
         res.setCalculationTimestamp(CalendarUtils.getNow());
         res.setChecksumSpec(csSpec);
-        try {
-            res.setChecksumValue(Base16Utils.encodeBase16(checksum));
-        } catch (DecoderException e) {
-            log.error(e.getMessage());
-        }
+        res.setChecksumValue(Base16Utils.encodeBase16(checksum));
 
         return res;
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
@@ -312,8 +312,7 @@ public abstract class CommandLineClient {
             FileExchange fileexchange = ProtocolComponentFactory.getInstance().getFileExchange(settings);
             fileexchange.deleteFile(url);
         } catch (Exception e) {
-            System.err.println("Issue regarding removing file from server: " + e.getMessage());
-            e.printStackTrace();
+            output.error("Issue regarding removing file from server: " + e.getMessage());
         }
     }
 

--- a/bitrepository-client/src/main/java/org/bitrepository/modify/replacefile/conversation/ReplacingFile.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/modify/replacefile/conversation/ReplacingFile.java
@@ -31,7 +31,6 @@ import org.bitrepository.bitrepositorymessages.ReplaceFileRequest;
 import org.bitrepository.client.conversation.ConversationContext;
 import org.bitrepository.client.conversation.PerformingOperationState;
 import org.bitrepository.client.conversation.selector.SelectedComponentInfo;
-import org.bitrepository.client.exceptions.UnexpectedResponseException;
 import org.bitrepository.common.utils.ChecksumUtils;
 
 import java.util.Collection;
@@ -57,7 +56,7 @@ public class ReplacingFile extends PerformingOperationState {
     }
 
     @Override
-    protected void generateContributorCompleteEvent(MessageResponse msg) throws UnexpectedResponseException {
+    protected void generateContributorCompleteEvent(MessageResponse msg) {
         ReplaceFileFinalResponse response = (ReplaceFileFinalResponse) msg;
         getContext().getMonitor().contributorComplete(new ReplaceFileCompletePillarEvent(
                 response.getPillarID(),

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/Base16Utils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/Base16Utils.java
@@ -52,13 +52,13 @@ public class Base16Utils {
      * @param hexString The string to encode to base16.
      * @return The string encoded to base16.
      */
-    public static byte[] encodeBase16(String hexString) {
+    public static byte[] encodeBase16(String hexString) throws DecoderException {
         ArgumentValidator.checkNotNullOrEmpty(hexString, "String hexString");
         // TODO Java 17 has HexFormat.of().parseHex(s) - consider using instead
         try {
             return Hex.decodeHex(hexString);
         } catch (DecoderException e) {
-            throw new IllegalArgumentException("Bad hex-string '" + hexString + "': " + e.getMessage());
+            throw new DecoderException("The string '" + hexString + "' is not a valid hex-string.");
         }
     }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
@@ -267,13 +267,13 @@ public final class ChecksumUtils {
      */
     public static ChecksumSpecTYPE getDefault(Settings settings) {
         ChecksumSpecTYPE res = new ChecksumSpecTYPE();
-        res.setChecksumType(ChecksumType.valueOf(
-                settings.getRepositorySettings().getProtocolSettings().getDefaultChecksumType()));
+        res.setChecksumType(ChecksumType.valueOf(settings.getRepositorySettings().getProtocolSettings().getDefaultChecksumType()));
 
         try {
             verifyAlgorithm(res);
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalArgumentException("The settings contains an invalid default checksum specification.", e);
+            System.err.println("The default settings file contains an invalid checksum spec.");
+            System.exit(1);
         }
 
         return res;

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
@@ -272,8 +272,7 @@ public final class ChecksumUtils {
         try {
             verifyAlgorithm(res);
         } catch (NoSuchAlgorithmException e) {
-            System.err.println("The default settings file contains an invalid checksum spec.");
-            System.exit(1);
+            throw new IllegalArgumentException("The settings contains an invalid default checksum specification.", e);
         }
 
         return res;

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/Base16UtilsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/Base16UtilsTest.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.common.utils;
 
+import org.apache.commons.codec.DecoderException;
 import org.jaccept.structure.ExtendedTestCase;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -48,7 +49,7 @@ public class Base16UtilsTest extends ExtendedTestCase {
     }
     
     @Test(groups = { "regressiontest" })
-    public void decodeChecksum() throws Exception {
+    public void decodeChecksum() {
         addDescription("Validating the decoding of the checksums.");
         addStep("Decode the checksum and validate.", "It should match the precalculated constant.");
         String decodedChecksum = Base16Utils.decodeBase16(ENCODED_CHECKSUM);
@@ -56,23 +57,12 @@ public class Base16UtilsTest extends ExtendedTestCase {
     }
     
     @Test(groups = { "regressiontest" })
-    public void badArgumentTest() throws Exception {
+    public void badArgumentTest() {
         addDescription("Test bad arguments");
-        Assert.assertNull(Base16Utils.decodeBase16(null));
-        
-        try {
-            Base16Utils.encodeBase16(null);
-            Assert.fail("Should throw an exception");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
-        
-        addStep("Test with a odd number of characters.", "Should throw an exception");
-        try {
-            Base16Utils.encodeBase16("123");
-            Assert.fail("Should throw an exception");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        Assert.assertThrows(IllegalArgumentException.class, () -> Base16Utils.encodeBase16(null));
+
+        addStep("Test with an odd number of characters.", "Should throw a decoder exception");
+        Assert.assertThrows(DecoderException.class, () -> Base16Utils.encodeBase16("123"));
+
     }
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/TestFileHelper.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/TestFileHelper.java
@@ -5,22 +5,23 @@
  * Copyright (C) 2010 - 2012 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.common.utils;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
@@ -48,8 +49,12 @@ public class TestFileHelper {
         ChecksumSpecTYPE checksumSpecTYPE = new ChecksumSpecTYPE();
         checksumSpecTYPE.setChecksumType(ChecksumType.MD5);
         checksumData.setChecksumSpec(checksumSpecTYPE);
-        checksumData.setChecksumValue(Base16Utils.encodeBase16(
-                ChecksumUtils.generateChecksum(getDefaultFile(), checksumSpecTYPE)));
+        try {
+            checksumData.setChecksumValue(Base16Utils.encodeBase16(ChecksumUtils.generateChecksum(getDefaultFile(), checksumSpecTYPE)));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
+
         return checksumData;
     }
 
@@ -58,7 +63,7 @@ public class TestFileHelper {
     }
 
     public static InputStream getFile(String name) {
-        String fullName = TEST_RESOURCES_PATH+name;
+        String fullName = TEST_RESOURCES_PATH + name;
         InputStream fileStream = TestFileHelper.class.getClassLoader().getResourceAsStream(fullName);
         assert (fileStream != null) : "Unable to find " + fullName + " in classpath";
         return fileStream;
@@ -71,20 +76,20 @@ public class TestFileHelper {
     public static String[] createFileIDs(int numberToCreate, String testName) {
         String uniquePrefix = createUniquePrefix(testName);
         String[] fileIDs = new String[numberToCreate];
-        for (int i = 0 ; i<numberToCreate ; i++) {
-            fileIDs[i] = uniquePrefix + "-" + (i+1) +".txt";
+        for (int i = 0; i < numberToCreate; i++) {
+            fileIDs[i] = uniquePrefix + "-" + (i + 1) + ".txt";
         }
         return fileIDs;
     }
-    
+
     public static List<File> getAllFilesFromSubDirs(File dir) {
         List<File> res = new ArrayList<>();
-        if(dir.isDirectory()) {
-            for(File f : dir.listFiles()) {
-                if(f.isFile()) {
+        if (dir.isDirectory()) {
+            for (File f : dir.listFiles()) {
+                if (f.isFile()) {
                     res.add(f);
                 } else {
-                    for(File sf : getAllFilesFromSubDirs(f)) {
+                    for (File sf : getAllFilesFromSubDirs(f)) {
                         res.add(sf);
                     }
                 }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/utils/MessageDataTypeValidatorTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/utils/MessageDataTypeValidatorTest.java
@@ -1,5 +1,6 @@
 package org.bitrepository.protocol.utils;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
@@ -27,7 +28,7 @@ public class MessageDataTypeValidatorTest {
     }
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
-    public void validateChecksumDataForFileNoTimestampTest() {
+    public void validateChecksumDataForFileNoTimestampTest() throws DecoderException {
         ChecksumDataForFileTYPE noChecksumSpec = new ChecksumDataForFileTYPE();
         ChecksumSpecTYPE checksumTypeSpec = new ChecksumSpecTYPE();
         checksumTypeSpec.setChecksumType(ChecksumType.MD5);
@@ -38,7 +39,7 @@ public class MessageDataTypeValidatorTest {
     }
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
-    public void validateChecksumDataForFileNoChecksumSpecTest() {
+    public void validateChecksumDataForFileNoChecksumSpecTest() throws DecoderException {
         ChecksumDataForFileTYPE noChecksumSpec = new ChecksumDataForFileTYPE();
         noChecksumSpec.setChecksumValue(Base16Utils.encodeBase16("abab"));
         noChecksumSpec.setCalculationTimestamp(CalendarUtils.getNow());
@@ -51,7 +52,11 @@ public class MessageDataTypeValidatorTest {
         ChecksumDataForFileTYPE noChecksumSpec = new ChecksumDataForFileTYPE();
         ChecksumSpecTYPE checksumTypeSpec = new ChecksumSpecTYPE();
         noChecksumSpec.setChecksumSpec(checksumTypeSpec);
-        noChecksumSpec.setChecksumValue(Base16Utils.encodeBase16("abab"));
+        try {
+            noChecksumSpec.setChecksumValue(Base16Utils.encodeBase16("abab"));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         noChecksumSpec.setCalculationTimestamp(CalendarUtils.getNow());
 
         MessageDataTypeValidator.validate(noChecksumSpec, "noChecksumSpec");

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/utils/MessageDataTypeValidatorTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/utils/MessageDataTypeValidatorTest.java
@@ -48,15 +48,11 @@ public class MessageDataTypeValidatorTest {
     }
 
     //@Test(expectedExceptions = {IllegalArgumentException.class})
-    public void validateChecksumDataForFileInvalidChecksumSpecTest() {
+    public void validateChecksumDataForFileInvalidChecksumSpecTest() throws DecoderException {
         ChecksumDataForFileTYPE noChecksumSpec = new ChecksumDataForFileTYPE();
         ChecksumSpecTYPE checksumTypeSpec = new ChecksumSpecTYPE();
         noChecksumSpec.setChecksumSpec(checksumTypeSpec);
-        try {
-            noChecksumSpec.setChecksumValue(Base16Utils.encodeBase16("abab"));
-        } catch (DecoderException e) {
-            System.err.println(e.getMessage());
-        }
+        noChecksumSpec.setChecksumValue(Base16Utils.encodeBase16("abab"));
         noChecksumSpec.setCalculationTimestamp(CalendarUtils.getNow());
 
         MessageDataTypeValidator.validate(noChecksumSpec, "noChecksumSpec");

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
@@ -107,7 +107,7 @@ public class SaltedChecksumWorkflow extends Workflow {
      *
      * @return The actual {@link ChecksumSpecTYPE}.
      */
-    private ChecksumSpecTYPE getChecksumSpecWithRandomSalt() {
+    private ChecksumSpecTYPE getChecksumSpecWithRandomSalt() throws IllegalArgumentException {
         ChecksumType defaultChecksum = ChecksumType.valueOf(
                 context.getSettings().getRepositorySettings().getProtocolSettings().getDefaultChecksumType());
         ChecksumSpecTYPE res = new ChecksumSpecTYPE();
@@ -133,7 +133,7 @@ public class SaltedChecksumWorkflow extends Workflow {
         try {
             res.setChecksumSalt(Base16Utils.encodeBase16(salt));
         } catch (DecoderException e) {
-            log.error(e.getMessage());
+            throw new IllegalArgumentException("Failed to set random salt.", e);
         }
 
         return res;

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.integrityservice.workflow;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
 import org.bitrepository.bitrepositoryelements.FileAction;
@@ -35,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -56,7 +56,6 @@ public class SaltedChecksumWorkflow extends Workflow {
     protected IntegrityWorkflowContext context;
     protected String collectionID;
     protected IntegrityContributors integrityContributors;
-    protected Date workflowStart;
     protected WorkflowStep step = null;
 
     /**
@@ -131,7 +130,11 @@ public class SaltedChecksumWorkflow extends Workflow {
         }
 
         String salt = UUID.randomUUID().toString().replace("-", "");
-        res.setChecksumSalt(Base16Utils.encodeBase16(salt));
+        try {
+            res.setChecksumSalt(Base16Utils.encodeBase16(salt));
+        } catch (DecoderException e) {
+            log.error(e.getMessage());
+        }
 
         return res;
     }

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDAOTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDAOTest.java
@@ -24,6 +24,7 @@
  */
 package org.bitrepository.integrityservice.cache;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.FileIDsData;
 import org.bitrepository.bitrepositoryelements.FileIDsData.FileIDsDataItems;
@@ -718,7 +719,11 @@ public class IntegrityDAOTest extends IntegrityDatabaseTestCase {
         List<ChecksumDataForChecksumSpecTYPE> res = new ArrayList<>();
         
         ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
-        csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         csData.setCalculationTimestamp(CalendarUtils.getNow());
         csData.setFileID(fileID);
         res.add(csData);

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDBToolsTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDBToolsTest.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.integrityservice.cache;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.FileIDsData;
 import org.bitrepository.bitrepositoryelements.FileIDsData.FileIDsDataItems;
@@ -284,7 +285,11 @@ public class IntegrityDBToolsTest extends IntegrityDatabaseTestCase {
         List<ChecksumDataForChecksumSpecTYPE> res = new ArrayList<>();
         
         ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
-        csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         csData.setCalculationTimestamp(CalendarUtils.getNow());
         csData.setFileID(fileID);
         res.add(csData);

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDatabaseTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDatabaseTest.java
@@ -24,6 +24,7 @@
  */
 package org.bitrepository.integrityservice.cache;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.FileIDsData;
 import org.bitrepository.bitrepositoryelements.FileIDsData.FileIDsDataItems;
@@ -77,14 +78,14 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
     }
 
     @Test(groups = {"regressiontest", "databasetest", "integritytest"})
-    public void instantiationTest() throws Exception {
+    public void instantiationTest() {
         addDescription("Tests that the connection can be instantaited.");
         IntegrityDatabase integrityCache = new IntegrityDatabase(settings);
         Assert.assertNotNull(integrityCache);
     }
 
     @Test(groups = {"regressiontest", "databasetest", "integritytest"})
-    public void initialStateExtractionTest() throws Exception {
+    public void initialStateExtractionTest() {
         addDescription("Tests the initial state of the IntegrityModel. Should not contain any data.");
         IntegrityModel model = new IntegrityDatabase(settings);
         
@@ -122,7 +123,7 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
     }
     
     @Test(groups = {"regressiontest", "databasetest", "integritytest"})
-    public void testIngestOfFileIDsData() throws Exception {
+    public void testIngestOfFileIDsData() {
         addDescription("Tests the ingesting of file ids data");
         IntegrityModel model = new IntegrityDatabase(settings);
         
@@ -143,7 +144,7 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
     }
 
     @Test(groups = {"regressiontest", "databasetest", "integritytest"})
-    public void testIngestOfChecksumsData() throws Exception {
+    public void testIngestOfChecksumsData() {
         addDescription("Tests the ingesting of checksums data");
         IntegrityModel model = new IntegrityDatabase(settings);
         
@@ -163,7 +164,7 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
     }
     
     @Test(groups = {"regressiontest", "databasetest", "integritytest"})
-    public void testDeletingEntry() throws Exception {
+    public void testDeletingEntry() {
         addDescription("Tests the deletion of an FileID entry.");
         IntegrityModel model = new IntegrityDatabase(settings);
 
@@ -191,7 +192,11 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
         List<ChecksumDataForChecksumSpecTYPE> res = new ArrayList<>();
         
         ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
-        csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         csData.setCalculationTimestamp(CalendarUtils.getNow());
         csData.setFileID(fileID);
         res.add(csData);
@@ -220,7 +225,7 @@ public class IntegrityDatabaseTest extends IntegrityDatabaseTestCase {
      */
     private List<String> getIssuesFromIterator(IntegrityIssueIterator it) {
         List<String> issues = new ArrayList<>();
-        String issue = null;
+        String issue;
         while((issue = it.getNextIntegrityIssue()) != null) {
             issues.add(issue);
         }

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/integrationtest/MissingChecksumTests.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/integrationtest/MissingChecksumTests.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.integrityservice.integrationtest;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.access.ContributorQuery;
 import org.bitrepository.access.getchecksums.conversation.ChecksumsCompletePillarEvent;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
@@ -146,7 +147,7 @@ public class MissingChecksumTests extends ExtendedTestCase {
         populateDatabase(model, TEST_FILE_1);
         
         addStep("Add checksum results for only one pillar.", "");
-        final ResultingChecksums resultingChecksums = createResultingChecksums(DEFAULT_CHECKSUM, TEST_FILE_1);
+        final ResultingChecksums resultingChecksums = createResultingChecksums(TEST_FILE_1);
         doAnswer(invocation -> {
             EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
             eventHandler.handleEvent(new IdentificationCompleteEvent(TEST_COLLECTION, Arrays.asList(PILLAR_1, PILLAR_2)));
@@ -192,7 +193,7 @@ public class MissingChecksumTests extends ExtendedTestCase {
         populateDatabase(model, TEST_FILE_1);
         
         addStep("Add checksum results for both pillar.", "");
-        final ResultingChecksums resultingChecksums = createResultingChecksums(DEFAULT_CHECKSUM, TEST_FILE_1);
+        final ResultingChecksums resultingChecksums = createResultingChecksums(TEST_FILE_1);
         doAnswer(invocation -> {
             EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
             eventHandler.handleEvent(new IdentificationCompleteEvent(TEST_COLLECTION, Arrays.asList(PILLAR_1, PILLAR_2)));
@@ -278,18 +279,22 @@ public class MissingChecksumTests extends ExtendedTestCase {
         model.addFileIDs(data, PILLAR_2, collectionID);
     }
     
-    private ResultingChecksums createResultingChecksums(String checksum, String ... fileIDs) {
+    private ResultingChecksums createResultingChecksums(String... fileIDs) {
         ResultingChecksums res = new ResultingChecksums();
-        res.getChecksumDataItems().addAll(createChecksumData(checksum, fileIDs));
+        res.getChecksumDataItems().addAll(createChecksumData(fileIDs));
         return res;
     }
     
-    private List<ChecksumDataForChecksumSpecTYPE> createChecksumData(String checksum, String ... fileIDs) {
+    private List<ChecksumDataForChecksumSpecTYPE> createChecksumData(String... fileIDs) {
         List<ChecksumDataForChecksumSpecTYPE> res = new ArrayList<>();
         for(String fileID : fileIDs) {
             ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
             csData.setCalculationTimestamp(CalendarUtils.getNow());
-            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+            try {
+                csData.setChecksumValue(Base16Utils.encodeBase16(MissingChecksumTests.DEFAULT_CHECKSUM));
+            } catch (DecoderException e) {
+                System.err.println(e.getMessage());
+            }
             csData.setFileID(fileID);
             res.add(csData);
         }

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflowTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflowTest.java
@@ -5,22 +5,23 @@
  * Copyright (C) 2010 - 2013 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.integrityservice.workflow;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.access.getchecksums.conversation.ChecksumsCompletePillarEvent;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
@@ -42,7 +43,6 @@ import org.bitrepository.integrityservice.collector.IntegrityInformationCollecto
 import org.bitrepository.service.audit.AuditTrailManager;
 import org.bitrepository.service.workflow.Workflow;
 import org.jaccept.structure.ExtendedTestCase;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -61,11 +61,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
-    
+
     private static final String PILLAR_1 = "pillar1";
     private static final String PILLAR_2 = "pillar2";
     private static final String PILLAR_3 = "pillar3";
-    
+
     private static final String TEST_FILE_1 = "test-file-1";
     private String TEST_COLLECTION;
 
@@ -74,7 +74,7 @@ public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
     protected IntegrityAlerter alerter;
     protected IntegrityModel model;
     protected AuditTrailManager auditManager;
-    
+
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
         settings = TestSettingsProvider.reloadSettings("IntegrityWorkflowTest");
@@ -83,10 +83,10 @@ public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
         settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR_1);
         settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR_2);
         settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR_3);
-        
+
         TEST_COLLECTION = settings.getRepositorySettings().getCollections().getCollection().get(0).getID();
         SettingsUtils.initialize(settings);
-        
+
         collector = mock(IntegrityInformationCollector.class);
         alerter = mock(IntegrityAlerter.class);
         model = mock(IntegrityModel.class);
@@ -94,7 +94,7 @@ public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
     }
 
     @Test(groups = {"regressiontest", "integritytest"})
-    public void testNoFilesInCollection() throws Exception {
+    public void testNoFilesInCollection() {
         addDescription("Test that the workflow does nothing, when it has no files in the collection.");
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(0));
@@ -105,94 +105,96 @@ public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
-        
+
         verifyNoInteractions(collector);
         verifyNoInteractions(auditManager);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verifyNoMoreInteractions(model);
     }
-    
+
     @Test(groups = {"regressiontest", "integritytest"})
-    public void testSuccess() throws Exception {
+    public void testSuccess() {
         addDescription("Test that the workflow works when both pillars deliver the same checksum.");
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(1));
         when(model.getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L))).thenReturn(TEST_FILE_1);
-        
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
-                return null;
-            }
+
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
+            return null;
         }).when(collector).getChecksums(anyString(), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
-        
+
         addStep("Run workflow for checking salted checksum.", "Should send alarm about failure");
 
         Workflow workflow = new SaltedChecksumWorkflow();
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verifyNoInteractions(alerter);
-        
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verify(model).getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L));
         verifyNoMoreInteractions(model);
-        
+
         verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(), anyString(), any(), any(), any());
         verifyNoMoreInteractions(auditManager);
     }
 
     @Test(groups = {"regressiontest", "integritytest"})
-    public void testOneComponentFailureAndTwoOtherAgreeOnChecksum() throws Exception {
+    public void testOneComponentFailureAndTwoOtherAgreeOnChecksum() {
         addDescription("Test that the workflow works when both pillars deliver the same checksum.");
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(1));
         when(model.getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L))).thenReturn(TEST_FILE_1);
-        
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                ContributorEvent e1 = new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e2 = new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e3 = new ContributorFailedEvent(PILLAR_3, TEST_COLLECTION, ResponseCode.FAILURE);
-                eventHandler.handleEvent(e1);
-                eventHandler.handleEvent(e2);
-                eventHandler.handleEvent(e3);
-                eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
-                return null;
-            }
+
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
+            ContributorEvent e1 = new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e2 = new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e3 = new ContributorFailedEvent(PILLAR_3, TEST_COLLECTION, ResponseCode.FAILURE);
+            eventHandler.handleEvent(e1);
+            eventHandler.handleEvent(e2);
+            eventHandler.handleEvent(e3);
+            eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
+            return null;
         }).when(collector).getChecksums(anyString(), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
-        
+
         addStep("Run workflow for checking salted checksum.", "Should send alarm about failure");
 
         Workflow workflow = new SaltedChecksumWorkflow();
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
-        
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verify(model).getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L));
         verifyNoMoreInteractions(model);
-        
+
         verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(), anyString(), any(), any(), any());
         verifyNoMoreInteractions(auditManager);
     }
@@ -203,127 +205,132 @@ public class SaltedChecksumWorkflowTest extends ExtendedTestCase {
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(1));
         when(model.getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L))).thenReturn(TEST_FILE_1);
-        
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                ResultingChecksums res1 = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                ResultingChecksums res2 = createResultingChecksums((String) invocation.getArguments()[3], "fedcba");
-                ContributorEvent e1 = new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res1, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e2 = new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res2, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e3 = new ContributorFailedEvent(PILLAR_3, TEST_COLLECTION, ResponseCode.FAILURE);
-                eventHandler.handleEvent(e1);
-                eventHandler.handleEvent(e2);
-                eventHandler.handleEvent(e3);
-                eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
-                return null;
-            }
+
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            ResultingChecksums res1 = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
+            ResultingChecksums res2 = createResultingChecksums((String) invocation.getArguments()[3], "fedcba");
+            ContributorEvent e1 = new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res1,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e2 = new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res2,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e3 = new ContributorFailedEvent(PILLAR_3, TEST_COLLECTION, ResponseCode.FAILURE);
+            eventHandler.handleEvent(e1);
+            eventHandler.handleEvent(e2);
+            eventHandler.handleEvent(e3);
+            eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
+            return null;
         }).when(collector).getChecksums(anyString(), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
-        
+
         addStep("Run workflow for checking salted checksum.", "Should send alarm about failure");
 
         Workflow workflow = new SaltedChecksumWorkflow();
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verify(alerter, times(2)).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
-        
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verify(model).getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L));
         verifyNoMoreInteractions(model);
-        
+
         verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(), anyString(), any(), any(), any());
         verifyNoMoreInteractions(auditManager);
     }
 
     @Test(groups = {"regressiontest", "integritytest"})
-    public void testInconsistentChecksums() throws Exception {
+    public void testInconsistentChecksums() {
         addDescription("Test that the workflow discovers and handles inconsistent checksums");
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(1));
         when(model.getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L))).thenReturn(TEST_FILE_1);
-        
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                ResultingChecksums res1 = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                ResultingChecksums res2 = createResultingChecksums((String) invocation.getArguments()[3], "fedcba");
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res1, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res2, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
-                return null;
-            }
+
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            ResultingChecksums res1 = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
+            ResultingChecksums res2 = createResultingChecksums((String) invocation.getArguments()[3], "fedcba");
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(PILLAR_1, TEST_COLLECTION, res1, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(PILLAR_2, TEST_COLLECTION, res2, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
+            return null;
         }).when(collector).getChecksums(anyString(), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
-        
+
         addStep("Run workflow for checking salted checksum.", "Should send alarm about failure");
 
         Workflow workflow = new SaltedChecksumWorkflow();
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verify(model).getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L));
         verifyNoMoreInteractions(model);
-        
-        verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(), 
+
+        verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(),
                 anyString(), any(), any(), any());
         verifyNoMoreInteractions(auditManager);
-        
+
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
     }
 
     @Test(groups = {"regressiontest", "integritytest"})
-    public void testNoReceivedChecksums() throws Exception {
+    public void testNoReceivedChecksums() {
         addDescription("Test that the workflow handles the case, when no checksums are received");
         addStep("Prepare for calls to mocks", "");
         when(model.getNumberOfFilesInCollection(anyString())).thenReturn(Long.valueOf(1));
         when(model.getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L))).thenReturn(TEST_FILE_1);
-        
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "", null));
-                return null;
-            }
+
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "", null));
+            return null;
         }).when(collector).getChecksums(anyString(), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
-        
+
         addStep("Run workflow for checking salted checksum.", "Should send alarm about failure");
 
         Workflow workflow = new SaltedChecksumWorkflow();
         IntegrityWorkflowContext context = new IntegrityWorkflowContext(settings, collector, model, alerter, auditManager);
         workflow.initialise(context, TEST_COLLECTION);
         workflow.start();
-        
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(), anyString(), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
-        
+
         verify(model).getNumberOfFilesInCollection(eq(TEST_COLLECTION));
         verify(model).getFileIDAtPosition(eq(TEST_COLLECTION), eq(0L));
         verifyNoMoreInteractions(model);
-        
-        verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(), 
+
+        verify(auditManager).addAuditEvent(eq(TEST_COLLECTION), anyString(), anyString(), anyString(),
                 anyString(), any(), any(), any());
         verifyNoMoreInteractions(auditManager);
-        
+
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
     }
-    
+
     private ResultingChecksums createResultingChecksums(String fileId, String checksum) {
         ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
         csData.setCalculationTimestamp(CalendarUtils.getNow());
         csData.setFileID(fileId);
-        csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
+
         ResultingChecksums res = new ResultingChecksums();
         res.getChecksumDataItems().add(csData);
         return res;

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/step/GetChecksumForFileStepTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/step/GetChecksumForFileStepTest.java
@@ -5,22 +5,23 @@
  * Copyright (C) 2010 - 2012 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.integrityservice.workflow.step;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.access.getchecksums.conversation.ChecksumsCompletePillarEvent;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
@@ -35,7 +36,6 @@ import org.bitrepository.common.utils.Base16Utils;
 import org.bitrepository.common.utils.CalendarUtils;
 import org.bitrepository.common.utils.ChecksumUtils;
 import org.bitrepository.integrityservice.workflow.IntegrityContributors;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -55,15 +55,17 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * Performs the validation of the integrity for the checksums.
  */
 public class GetChecksumForFileStepTest extends WorkflowstepTest {
-    /** The settings for the tests. Should be instantiated in the setup.*/
+    /**
+     * The settings for the tests. Should be instantiated in the setup.
+     */
     public static final String TEST_PILLAR_1 = "test-pillar-1";
     public static final String TEST_PILLAR_2 = "test-pillar-2";
     public static final String TEST_PILLAR_3 = "test-pillar-3";
-    
+
     public static final String FILE_1 = "test-file-1";
     public static final String FILE_2 = "test-file-2";
     String TEST_COLLECTION = "test-collection";
-    
+
     @BeforeMethod(alwaysRun = true)
     public void setup() {
         super.setup();
@@ -74,25 +76,24 @@ public class GetChecksumForFileStepTest extends WorkflowstepTest {
         integrityContributors = new IntegrityContributors(Arrays.asList(TEST_PILLAR_1, TEST_PILLAR_2, TEST_PILLAR_3), 0);
     }
 
-    
+
     @Test(groups = {"regressiontest", "integritytest"})
     public void testNoResults() throws Exception {
         addDescription("Test step for retrieving the checksum of a single file, when no results are delivered.");
         ChecksumSpecTYPE checksumType = ChecksumUtils.getDefault(settings);
-        
+
         addStep("Setup mock answers", "");
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
-                return null;
-            }
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+            eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
+            return null;
         }).when(collector).getChecksums(
                 eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class), anyString(),
                 anyString(), any(), any(EventHandler.class));
 
-        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION, integrityContributors);
-        
+        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION,
+                integrityContributors);
+
         addStep("Validate the checksum results", "Should not have any results");
         step.performStep();
 
@@ -101,30 +102,35 @@ public class GetChecksumForFileStepTest extends WorkflowstepTest {
         verify(collector).getChecksums(anyString(), any(), eq(checksumType), eq(FILE_1), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
     }
-    
+
     @Test(groups = {"regressiontest", "integritytest"})
     public void testFullData() throws Exception {
         addDescription("Test step for retrieving the checksum of a single file, when all three pillars deliver results.");
         ChecksumSpecTYPE checksumType = ChecksumUtils.getDefault(settings);
-        
-        addStep("Setup mock answers", "");
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
 
-                ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(TEST_PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(TEST_PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new ChecksumsCompletePillarEvent(TEST_PILLAR_3, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false));
-                eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
-                return null;
-            }
+        addStep("Setup mock answers", "");
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+
+            ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3]);
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(TEST_PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(TEST_PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(
+                    new ChecksumsCompletePillarEvent(TEST_PILLAR_3, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2],
+                            false));
+            eventHandler.handleEvent(new CompleteEvent(TEST_COLLECTION, null));
+            return null;
         }).when(collector).getChecksums(
                 eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class), anyString(),
                 anyString(), any(), any(EventHandler.class));
 
-        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION, integrityContributors);
-        
+        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION,
+                integrityContributors);
+
         addStep("Validate the checksum results", "Should have checksum for each pillar.");
         step.performStep();
 
@@ -133,7 +139,7 @@ public class GetChecksumForFileStepTest extends WorkflowstepTest {
         Assert.assertTrue(step.getResults().containsKey(TEST_PILLAR_1));
         Assert.assertTrue(step.getResults().containsKey(TEST_PILLAR_2));
         Assert.assertTrue(step.getResults().containsKey(TEST_PILLAR_3));
-        
+
         verifyNoInteractions(alerter);
         verify(collector).getChecksums(anyString(), any(), eq(checksumType), eq(FILE_1), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
@@ -143,28 +149,29 @@ public class GetChecksumForFileStepTest extends WorkflowstepTest {
     public void testComponentFailure() throws Exception {
         addDescription("Test step for retrieving the checksum of a single file, when one pillar fails.");
         ChecksumSpecTYPE checksumType = ChecksumUtils.getDefault(settings);
-        
-        addStep("Setup mock answers", "");
-        doAnswer(new Answer<Void>() {
-            public Void answer(InvocationOnMock invocation) {
-                EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
 
-                ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3], "abcdef");
-                ContributorEvent e1 = new ChecksumsCompletePillarEvent(TEST_PILLAR_1, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e2 = new ChecksumsCompletePillarEvent(TEST_PILLAR_2, TEST_COLLECTION, res, (ChecksumSpecTYPE) invocation.getArguments()[2], false);
-                ContributorEvent e3 = new ContributorFailedEvent(TEST_PILLAR_3, TEST_COLLECTION, ResponseCode.REQUEST_NOT_UNDERSTOOD_FAILURE);
-                eventHandler.handleEvent(e1);
-                eventHandler.handleEvent(e2);
-                eventHandler.handleEvent(e3);
-                eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
-                return null;
-            }
+        addStep("Setup mock answers", "");
+        doAnswer((Answer<Void>) invocation -> {
+            EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
+
+            ResultingChecksums res = createResultingChecksums((String) invocation.getArguments()[3]);
+            ContributorEvent e1 = new ChecksumsCompletePillarEvent(TEST_PILLAR_1, TEST_COLLECTION, res,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e2 = new ChecksumsCompletePillarEvent(TEST_PILLAR_2, TEST_COLLECTION, res,
+                    (ChecksumSpecTYPE) invocation.getArguments()[2], false);
+            ContributorEvent e3 = new ContributorFailedEvent(TEST_PILLAR_3, TEST_COLLECTION, ResponseCode.REQUEST_NOT_UNDERSTOOD_FAILURE);
+            eventHandler.handleEvent(e1);
+            eventHandler.handleEvent(e2);
+            eventHandler.handleEvent(e3);
+            eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "COMPONENT FAILED", Arrays.asList(e1, e2, e3)));
+            return null;
         }).when(collector).getChecksums(
                 eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class), anyString(),
                 anyString(), any(), any(EventHandler.class));
 
-        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION, integrityContributors);
-        
+        GetChecksumForFileStep step = new GetChecksumForFileStep(collector, alerter, checksumType, FILE_1, settings, TEST_COLLECTION,
+                integrityContributors);
+
         addStep("Validate the file ids", "Should not have integrity issues.");
         step.performStep();
 
@@ -173,18 +180,22 @@ public class GetChecksumForFileStepTest extends WorkflowstepTest {
         Assert.assertTrue(step.getResults().containsKey(TEST_PILLAR_1));
         Assert.assertTrue(step.getResults().containsKey(TEST_PILLAR_2));
         Assert.assertFalse(step.getResults().containsKey(TEST_PILLAR_3));
-        
+
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
         verifyNoMoreInteractions(alerter);
         verify(collector).getChecksums(anyString(), any(), eq(checksumType), eq(FILE_1), anyString(), any(), any(EventHandler.class));
         verifyNoMoreInteractions(collector);
     }
-    
-    private ResultingChecksums createResultingChecksums(String fileId, String checksum) {
+
+    private ResultingChecksums createResultingChecksums(String fileId) {
         ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
         csData.setCalculationTimestamp(CalendarUtils.getNow());
         csData.setFileID(fileId);
-        csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16("abcdef"));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         ResultingChecksums res = new ResultingChecksums();
         res.getChecksumDataItems().add(csData);
         return res;

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/step/UpdateChecksumsStepTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/workflow/step/UpdateChecksumsStepTest.java
@@ -5,22 +5,23 @@
  * Copyright (C) 2010 - 2012 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.integrityservice.workflow.step;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.access.ContributorQuery;
 import org.bitrepository.access.getchecksums.conversation.ChecksumsCompletePillarEvent;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
@@ -78,9 +79,9 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class),
@@ -104,12 +105,12 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>());
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>());
         when(integrityContributors.getFailedContributors()).thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)));
-        
+
         settings.getReferenceSettings().getIntegrityServiceSettings().setAbortOnFailedContributor(true);
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         try {
             step.performStep();
@@ -122,17 +123,18 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
         verify(integrityContributors).failContributor(eq(TEST_PILLAR_1));
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testRetryCollectionWhenNegativeReply() throws WorkflowAbortedException {
         addDescription("Test the step for updating the file ids will retry on a FAILED event");
-        
+
         final ResultingChecksums resultingChecksums = createResultingChecksums(DEFAULT_CHECKSUM, TEST_FILE_1);
         doAnswer(new Answer() {
             boolean firstAnswer = true;
+
             public Void answer(InvocationOnMock invocation) {
                 EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
-                if(firstAnswer) {
+                if (firstAnswer) {
                     firstAnswer = false;
                     eventHandler.handleEvent(new ContributorFailedEvent(TEST_PILLAR_1, TEST_COLLECTION, ResponseCode.FAILURE));
                     eventHandler.handleEvent(new OperationFailedEvent(TEST_COLLECTION, "Problem encountered", null));
@@ -149,12 +151,12 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>());
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>());
         when(integrityContributors.getFailedContributors()).thenReturn(new HashSet<>());
 
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
         verify(collector, times(2)).getChecksums(eq(TEST_COLLECTION), any(),
@@ -163,9 +165,9 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
         verifyNoMoreInteractions(alerter);
         verify(integrityContributors).failContributor(eq(TEST_PILLAR_1));
         verify(integrityContributors).finishContributor(eq(TEST_PILLAR_1));
-        
+
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testContinueWorkflowNegativeReply() throws WorkflowAbortedException {
         addDescription("Test the step for updating the checksums will continue the workflow in case "
@@ -182,21 +184,21 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>());
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>());
         when(integrityContributors.getFailedContributors()).thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)));
-        
+
         settings.getReferenceSettings().getIntegrityServiceSettings().setAbortOnFailedContributor(false);
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
-        
+
         verify(integrityContributors).failContributor(eq(TEST_PILLAR_1));
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class), any(),
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
         verify(alerter).integrityFailed(anyString(), eq(TEST_COLLECTION));
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testIngestOfResults() throws WorkflowAbortedException {
         addDescription("Test the step for updating the checksums delivers the results to the integrity model.");
@@ -215,11 +217,11 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(),
@@ -246,9 +248,9 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new FullUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new FullUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(),
@@ -257,17 +259,18 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
         verify(model).addChecksums(resultingChecksums.getChecksumDataItems(), TEST_PILLAR_1, TEST_COLLECTION);
         verifyNoMoreInteractions(alerter);
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testPartialResults() throws WorkflowAbortedException {
         addDescription("Test that the number of partial is used for generating more than one request.");
         final ResultingChecksums resultingChecksums = createResultingChecksums(DEFAULT_CHECKSUM, TEST_FILE_1);
 
         addStep("Setup the collector mock to generate a isPartialResult=true event the first time and a " +
-                "isPartialResult=false the second time",
+                        "isPartialResult=false the second time",
                 "The collectors getFileIDs should be called 2 time. The same goes for the 'models' addFileIDs");
         doAnswer(new Answer() {
             boolean firstPage = true;
+
             public Void answer(InvocationOnMock invocation) {
                 EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
                 eventHandler.handleEvent(new IdentificationCompleteEvent(TEST_COLLECTION, Arrays.asList(TEST_PILLAR_1)));
@@ -282,11 +285,11 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
 
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
-            .thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1)))
+                .thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
 
         step.performStep();
@@ -294,11 +297,11 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
         verify(collector, times(2)).getChecksums(eq(TEST_COLLECTION), any(),
                 any(ChecksumSpecTYPE.class), any(), anyString(), any(ContributorQuery[].class), any(EventHandler.class));
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testFullChecksumCollection() throws WorkflowAbortedException {
         addDescription("Test that the full list of checksums is requested.");
-        
+
         doAnswer(new Answer() {
             public Void answer(InvocationOnMock invocation) {
                 EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
@@ -311,24 +314,25 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
 
         when(model.getDateForNewestChecksumEntryForPillar(anyString(), anyString())).thenReturn(new Date(0));
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new FullUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new FullUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
-        
-        ContributorQuery[] expectedContributorQueries = 
-                makeFullQueries(settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID(), model); 
-        
+
+        ContributorQuery[] expectedContributorQueries =
+                makeFullQueries(settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID(),
+                        model);
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class),
-        		any(), anyString(), eq(expectedContributorQueries), any(EventHandler.class));
+                any(), anyString(), eq(expectedContributorQueries), any(EventHandler.class));
         verifyNoMoreInteractions(alerter);
     }
-    
+
     @Test(groups = {"regressiontest"})
     public void testIncrementalChecksumCollection() throws WorkflowAbortedException {
         addDescription("Test that only the list of new checksums is requested.");
-        
+
         doAnswer(new Answer() {
             public Void answer(InvocationOnMock invocation) {
                 EventHandler eventHandler = (EventHandler) invocation.getArguments()[6];
@@ -338,55 +342,59 @@ public class UpdateChecksumsStepTest extends WorkflowstepTest {
         }).when(collector).getChecksums(
                 eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class), any(),
                 anyString(), any(ContributorQuery[].class), any(EventHandler.class));
-        
+
         when(integrityContributors.getActiveContributors())
-            .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
-        
-        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(), 
+                .thenReturn(new HashSet<>(Arrays.asList(TEST_PILLAR_1))).thenReturn(new HashSet<>());
+
+        UpdateChecksumsStep step = new IncrementalUpdateChecksumsStep(collector, model, alerter, createChecksumSpecTYPE(),
                 settings, TEST_COLLECTION, integrityContributors);
         step.performStep();
-        
-        ContributorQuery[] expectedContributorQueries = 
-                makeQueries(settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID(), model); 
-        
+
+        ContributorQuery[] expectedContributorQueries =
+                makeQueries(settings.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID(), model);
+
         verify(collector).getChecksums(eq(TEST_COLLECTION), any(), any(ChecksumSpecTYPE.class),
-        		any(), anyString(), eq(expectedContributorQueries), any(EventHandler.class));
+                any(), anyString(), eq(expectedContributorQueries), any(EventHandler.class));
         verifyNoMoreInteractions(alerter);
     }
-    
+
     private ContributorQuery[] makeFullQueries(List<String> pillars, IntegrityModel store) {
         List<ContributorQuery> res = new ArrayList<>();
-        for(String pillar : pillars) {
+        for (String pillar : pillars) {
             Date latestChecksumDate = new Date(0);
             res.add(new ContributorQuery(pillar, latestChecksumDate, null, SettingsUtils.DEFAULT_MAX_CLIENT_PAGE_SIZE));
         }
-        
+
         return res.toArray(new ContributorQuery[pillars.size()]);
     }
-    
+
     private ContributorQuery[] makeQueries(List<String> pillars, IntegrityModel store) {
         List<ContributorQuery> res = new ArrayList<>();
-        for(String pillar : pillars) {
-        	Date latestChecksumDate = store.getDateForNewestChecksumEntryForPillar(pillar, TEST_COLLECTION);
+        for (String pillar : pillars) {
+            Date latestChecksumDate = store.getDateForNewestChecksumEntryForPillar(pillar, TEST_COLLECTION);
             res.add(new ContributorQuery(pillar, latestChecksumDate, null, SettingsUtils.DEFAULT_MAX_CLIENT_PAGE_SIZE));
         }
-        
+
         return res.toArray(new ContributorQuery[pillars.size()]);
     }
-    
 
-    private ResultingChecksums createResultingChecksums(String checksum, String ... fileids) {
+
+    private ResultingChecksums createResultingChecksums(String checksum, String... fileids) {
         ResultingChecksums res = new ResultingChecksums();
         res.getChecksumDataItems().addAll(createChecksumData(checksum, fileids));
         return res;
     }
-    
-    private List<ChecksumDataForChecksumSpecTYPE> createChecksumData(String checksum, String ... fileids) {
+
+    private List<ChecksumDataForChecksumSpecTYPE> createChecksumData(String checksum, String... fileids) {
         List<ChecksumDataForChecksumSpecTYPE> res = new ArrayList<>();
-        for(String fileID : fileids) {
+        for (String fileID : fileids) {
             ChecksumDataForChecksumSpecTYPE csData = new ChecksumDataForChecksumSpecTYPE();
             csData.setCalculationTimestamp(CalendarUtils.getNow());
-            csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+            try {
+                csData.setChecksumValue(Base16Utils.encodeBase16(checksum));
+            } catch (DecoderException e) {
+                System.err.println(e.getMessage());
+            }
             csData.setFileID(fileID);
             res.add(csData);
         }

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/IdentifyPillarsForPutFileRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/IdentifyPillarsForPutFileRequestHandler.java
@@ -128,6 +128,7 @@ public class IdentifyPillarsForPutFileRequestHandler extends IdentifyRequestHand
         response.setChecksumDataForExistingFile(getPillarModel().getChecksumDataForFile(message.getFileID(), message.getCollectionID(),
                 ChecksumUtils.getDefault(getSettings())));
 
+
         ResponseInfo irInfo = new ResponseInfo();
         irInfo.setResponseCode(ResponseCode.DUPLICATE_FILE_FAILURE);
         response.setResponseInfo(irInfo);

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
@@ -24,6 +24,7 @@
  */
 package org.bitrepository.pillar.store;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ResponseCode;
@@ -172,7 +173,12 @@ public abstract class StorageModel {
         ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
         res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.getCalculationDate()));
         res.setChecksumSpec(csType);
-        res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+        try {
+            res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+        } catch (DecoderException e) {
+            log.error(e.getMessage());
+        }
+
         return res;
     }
 

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
@@ -176,7 +176,7 @@ public abstract class StorageModel {
         try {
             res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
         } catch (DecoderException e) {
-            log.error(e.getMessage());
+            throw new IllegalArgumentException("Could not encode checksum.", e);
         }
 
         return res;

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
@@ -21,9 +21,12 @@
  */
 package org.bitrepository.pillar.store.checksumdatabase;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.common.utils.Base16Utils;
 import org.bitrepository.common.utils.CalendarUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +37,7 @@ import java.util.List;
 public class ExtractedChecksumResultSet {
     protected final List<ChecksumDataForChecksumSpecTYPE> entries;
     protected boolean moreEntriesReported;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     public ExtractedChecksumResultSet() {
         entries = new ArrayList<>();
@@ -57,7 +61,12 @@ public class ExtractedChecksumResultSet {
     public void insertChecksumEntry(ChecksumEntry entry) {
         ChecksumDataForChecksumSpecTYPE res = new ChecksumDataForChecksumSpecTYPE();
         res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.getCalculationDate()));
-        res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+        try {
+            res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+        } catch (DecoderException e) {
+            log.error(e.getMessage());
+        }
+
         res.setFileID(entry.getFileId());
         entries.add(res);
     }

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
@@ -64,7 +64,7 @@ public class ExtractedChecksumResultSet {
         try {
             res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
         } catch (DecoderException e) {
-            log.error(e.getMessage());
+            throw new IllegalArgumentException("Could not encode checksum.", e);
         }
 
         res.setFileID(entry.getFileId());

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/DefaultPillarTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/DefaultPillarTest.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.pillar;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
@@ -63,7 +64,11 @@ public abstract class DefaultPillarTest extends DefaultFixturePillarTest {
         ChecksumSpecTYPE checksumSpecTYPE = new ChecksumSpecTYPE();
         checksumSpecTYPE.setChecksumType(ChecksumType.MD5);
         EMPTY_FILE_CHECKSUM_DATA.setChecksumSpec(checksumSpecTYPE);
-        EMPTY_FILE_CHECKSUM_DATA.setChecksumValue(Base16Utils.encodeBase16(EMPTY_FILE_CHECKSUM));
+        try {
+            EMPTY_FILE_CHECKSUM_DATA.setChecksumValue(Base16Utils.encodeBase16(EMPTY_FILE_CHECKSUM));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
     }
     @Override
     protected void initializeCUT() {

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/MockedPillarTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/MockedPillarTest.java
@@ -5,22 +5,23 @@
  * Copyright (C) 2010 - 2012 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.pillar;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
@@ -75,7 +76,7 @@ public abstract class MockedPillarTest extends DefaultFixturePillarTest {
         PillarAlarmDispatcher alarmDispatcher = new PillarAlarmDispatcher(settingsForCUT, messageBus);
         context = new MessageHandlerContext(settingsForCUT,
                 SettingsHelper.getPillarCollections(settingsForCUT.getComponentID(), settingsForCUT.getCollections()),
-                new ResponseDispatcher(settingsForCUT, messageBus), 
+                new ResponseDispatcher(settingsForCUT, messageBus),
                 alarmDispatcher,
                 audits, fileExchangeMock);
         mediator = new PillarMediator(messageBus, context, model);
@@ -84,7 +85,7 @@ public abstract class MockedPillarTest extends DefaultFixturePillarTest {
         csSpec = new ChecksumSpecTYPE();
         csSpec.setChecksumSalt(null);
         csSpec.setChecksumType(ChecksumType.MD5);
-        
+
         otherCsSpec = new ChecksumSpecTYPE();
         otherCsSpec.setChecksumSalt(new byte[]{'a', 'b'});
         otherCsSpec.setChecksumType(ChecksumType.HMAC_SHA512);
@@ -92,16 +93,21 @@ public abstract class MockedPillarTest extends DefaultFixturePillarTest {
         csData = new ChecksumDataForFileTYPE();
         csData.setCalculationTimestamp(CalendarUtils.getEpoch());
         csData.setChecksumSpec(csSpec);
-        csData.setChecksumValue(Base16Utils.encodeBase16(DEFAULT_MD5_CHECKSUM));
 
         NON_DEFAULT_CS = new ChecksumDataForFileTYPE();
         NON_DEFAULT_CS.setCalculationTimestamp(CalendarUtils.getEpoch());
         NON_DEFAULT_CS.setChecksumSpec(csSpec);
-        NON_DEFAULT_CS.setChecksumValue(Base16Utils.encodeBase16(NON_DEFAULT_MD5_CHECKSUM));
+
+        try {
+            csData.setChecksumValue(Base16Utils.encodeBase16(DEFAULT_MD5_CHECKSUM));
+            NON_DEFAULT_CS.setChecksumValue(Base16Utils.encodeBase16(NON_DEFAULT_MD5_CHECKSUM));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
     }
 
     public void shutdownMediator() {
-        if(mediator != null) {
+        if (mediator != null) {
             mediator.close();
             mediator = null;
         }

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/func/deletefile/DeleteFileRequestIT.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/func/deletefile/DeleteFileRequestIT.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.pillar.integration.func.deletefile;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
 import org.bitrepository.bitrepositoryelements.ResponseCode;
@@ -95,8 +96,12 @@ public class DeleteFileRequestIT extends DefaultPillarOperationTest {
         
         ChecksumSpecTYPE requestedChecksumSpec = new ChecksumSpecTYPE();
         requestedChecksumSpec.setChecksumType(ChecksumType.HMAC_MD5);
-        requestedChecksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
-        
+        try {
+            requestedChecksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
+
         DeleteFileRequest deleteRequest = msgFactory.createDeleteFileRequest(
                 TestFileHelper.getDefaultFileChecksum(), requestedChecksumSpec, testSpecificFileID);
         messageBus.sendMessage(deleteRequest);

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/func/getchecksums/GetChecksumTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/func/getchecksums/GetChecksumTest.java
@@ -21,6 +21,7 @@
  */
 package org.bitrepository.pillar.integration.func.getchecksums;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumType;
@@ -84,7 +85,11 @@ public class GetChecksumTest extends PillarFunctionTest {
             "The correct of SHA1 checksum should be returned (Not checked yet).");
         ChecksumSpecTYPE checksumSpec = new ChecksumSpecTYPE();
         checksumSpec.setChecksumType(ChecksumType.HMAC_MD5);
-        checksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
+        try {
+            checksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         List<ChecksumDataForChecksumSpecTYPE> checksums = pillarFileManager.getChecksums(
                 checksumSpec, null, DEFAULT_FILE_ID);
         assertNotNull(checksums.get(0));
@@ -99,7 +104,11 @@ public class GetChecksumTest extends PillarFunctionTest {
             "The correct of SHA1 checksum should be returned (Not checked yet).");
         ChecksumSpecTYPE checksumSpec = new ChecksumSpecTYPE();
         checksumSpec.setChecksumType(ChecksumType.HMAC_SHA1);
-        checksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
+        try {
+            checksumSpec.setChecksumSalt(Base16Utils.encodeBase16("abab"));
+        } catch (DecoderException e) {
+            System.err.println(e.getMessage());
+        }
         List<ChecksumDataForChecksumSpecTYPE> checksums = pillarFileManager.getChecksums(
                 checksumSpec, null, DEFAULT_FILE_ID);
         assertNotNull(checksums.get(0));

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/messagehandling/ReplaceFileTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/messagehandling/ReplaceFileTest.java
@@ -24,6 +24,7 @@
  */
 package org.bitrepository.pillar.messagehandling;
 
+import org.apache.commons.codec.DecoderException;
 import org.bitrepository.bitrepositoryelements.AlarmCode;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
@@ -66,23 +67,15 @@ public class ReplaceFileTest extends MockedPillarTest {
 
     @SuppressWarnings("rawtypes")
     @Test( groups = {"regressiontest", "pillartest"})
-    public void goodCaseIdentification() throws Exception {
+    public void goodCaseIdentification() {
         addDescription("Tests the identification for a ReplaceFile operation on the pillar for the successful scenario.");
         addStep("Set up constants and variables.", "Should not fail here!");
         String FILE_ID = DEFAULT_FILE_ID;
 
         addStep("Setup for having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -104,23 +97,15 @@ public class ReplaceFileTest extends MockedPillarTest {
 
     @SuppressWarnings("rawtypes")
     @Test( groups = {"regressiontest", "pillartest"})
-    public void badCaseIdentification() throws Exception {
+    public void badCaseIdentification() {
         addDescription("Tests the identification for a ReplaceFile operation on the pillar for the failure scenario, when the file does not exist.");
         addStep("Set up constants and variables.", "Should not fail here!");
         String FILE_ID = DEFAULT_FILE_ID;
 
         addStep("Setup for not having the file and delivering pillar id", 
                 "Should return false, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return false;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
+        doAnswer(invocation -> false).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -142,18 +127,14 @@ public class ReplaceFileTest extends MockedPillarTest {
 
     @SuppressWarnings("rawtypes")
     @Test( groups = {"regressiontest", "pillartest"})
-    public void badCaseOperationMissingFile() throws Exception {
+    public void badCaseOperationMissingFile() {
         addDescription("Tests the ReplaceFile operation on the pillar for the failure scenario, when the file is missing.");
         addStep("Set up constants and variables.", "Should not fail here!");
         String FILE_ID = DEFAULT_FILE_ID;
 
         addStep("Setup for not having the file and delivering pillar id", 
                 "Should return false, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return false;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> false).when(model).hasFileID(eq(FILE_ID), anyString());
         doAnswer(new Answer() {
             public String answer(InvocationOnMock invocation) {
                 return settingsForCUT.getComponentID();
@@ -178,7 +159,7 @@ public class ReplaceFileTest extends MockedPillarTest {
 
     @SuppressWarnings("rawtypes")
     @Test( groups = {"regressiontest", "pillartest"})
-    public void badCaseOperationNoDestructiveChecksum() throws Exception {
+    public void badCaseOperationNoDestructiveChecksum() {
         addDescription("Tests the ReplaceFile operation on the pillar for the failure scenario, when no validation "
                 + "checksum is given for the destructive action, but though is required.");
         addStep("Set up constants and variables.", "Should not fail here!");
@@ -187,16 +168,8 @@ public class ReplaceFileTest extends MockedPillarTest {
 
         addStep("Setup for having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -219,7 +192,7 @@ public class ReplaceFileTest extends MockedPillarTest {
 
     @SuppressWarnings("rawtypes")
     @Test( groups = {"regressiontest", "pillartest"})
-    public void badCaseOperationNoValidationChecksum() throws Exception {
+    public void badCaseOperationNoValidationChecksum() {
         addDescription("Tests the ReplaceFile operation on the pillar for the failure scenario, when no validation "
                 + "checksum is given for the new file, but though is required.");
         addStep("Set up constants and variables.", "Should not fail here!");
@@ -228,16 +201,8 @@ public class ReplaceFileTest extends MockedPillarTest {
 
         addStep("Setup for having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -268,21 +233,9 @@ public class ReplaceFileTest extends MockedPillarTest {
 
         addStep("Setup for having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return NON_DEFAULT_MD5_CHECKSUM;
-            }
-        }).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
+        doAnswer(invocation -> NON_DEFAULT_MD5_CHECKSUM).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -312,21 +265,9 @@ public class ReplaceFileTest extends MockedPillarTest {
 
         addStep("Setup for already having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return DEFAULT_MD5_CHECKSUM;
-            }
-        }).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
+        doAnswer(invocation -> DEFAULT_MD5_CHECKSUM).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
 
         addStep("Create and send the identify request message.",
                 "Should be received and handled by the pillar.");
@@ -364,38 +305,26 @@ public class ReplaceFileTest extends MockedPillarTest {
 
         addStep("Setup for already having the file and delivering pillar id", 
                 "Should return true, when requesting file-id existence.");
-        doAnswer(new Answer() {
-            public Boolean answer(InvocationOnMock invocation) {
-                return true;
-            }
-        }).when(model).hasFileID(eq(FILE_ID), anyString());
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return settingsForCUT.getComponentID();
-            }
-        }).when(model).getPillarID();
-        doAnswer(new Answer() {
-            public String answer(InvocationOnMock invocation) {
-                return DEFAULT_MD5_CHECKSUM;
-            }            
-        }).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
-        doAnswer(new Answer() {
-            public ChecksumDataForFileTYPE answer(InvocationOnMock invocation) {
-                ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
-                res.setChecksumSpec(otherCsSpec);
-                res.setCalculationTimestamp(CalendarUtils.getNow());
+        doAnswer(invocation -> true).when(model).hasFileID(eq(FILE_ID), anyString());
+        doAnswer(invocation -> settingsForCUT.getComponentID()).when(model).getPillarID();
+        doAnswer(invocation -> DEFAULT_MD5_CHECKSUM).when(model).getChecksumForFile(anyString(), anyString(), any(ChecksumSpecTYPE.class));
+        doAnswer(invocation -> {
+            ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
+            res.setChecksumSpec(otherCsSpec);
+            res.setCalculationTimestamp(CalendarUtils.getNow());
+            try {
                 res.setChecksumValue(Base16Utils.encodeBase16(NON_DEFAULT_MD5_CHECKSUM));
-                return res;
-            }            
+            } catch (DecoderException e) {
+                e.printStackTrace();
+            }
+            return res;
         }).when(model).getChecksumDataForFile(anyString(), anyString(), eq(otherCsSpec));
-        doAnswer(new Answer() {
-            public ChecksumDataForFileTYPE answer(InvocationOnMock invocation) {
-                ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
-                res.setChecksumSpec(csSpec);
-                res.setCalculationTimestamp(CalendarUtils.getNow());
-                res.setChecksumValue(Base16Utils.encodeBase16(DEFAULT_MD5_CHECKSUM));
-                return res;
-            }            
+        doAnswer(invocation -> {
+            ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
+            res.setChecksumSpec(csSpec);
+            res.setCalculationTimestamp(CalendarUtils.getNow());
+            res.setChecksumValue(Base16Utils.encodeBase16(DEFAULT_MD5_CHECKSUM));
+            return res;
         }).when(model).getChecksumDataForFile(anyString(), anyString(), eq(csSpec));
 
         addStep("Create and send the identify request message.",


### PR DESCRIPTION
Fixed exceptions being thrown if the commandline client arguments for the checksum algorithm or the hex-string was incorrect. Now it will return an easily readable message that tells the user what is wrong.

Also fixed a few other messages to be formatted in a more pretty way.