### PR TITLE
BITMAG-992 Reference now prefers new XxTimeoutDuration settings in repository settings over old ones

### DIFF
--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/FinishedState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/FinishedState.java
@@ -27,6 +27,7 @@ package org.bitrepository.client.conversation;
 import org.bitrepository.bitrepositorymessages.MessageResponse;
 import org.bitrepository.common.exceptions.UnableToFinishException;
 
+import java.time.Duration;
 import java.util.LinkedList;
 
 /**
@@ -54,8 +55,8 @@ public class FinishedState extends GeneralConversationState {
     }
 
     @Override
-    protected long getTimeoutValue() {
-        return 0;
+    protected Duration getTimeoutValue() {
+        return Duration.ZERO;
     }
 
     @Override

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/GeneralConversationState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/GeneralConversationState.java
@@ -74,7 +74,7 @@ public abstract class GeneralConversationState implements ConversationState {
     public void start() {
         try {
             if (!responseStatus.getOutstandingComponents().isEmpty()) {
-                if (getTimeoutValue().compareTo(Duration.ZERO) > 0) { // From Java 18 use: getTimeoutValue().isPositive()
+                if (getTimeoutValue().compareTo(Duration.ZERO) > 0) { // TODO From Java 18 use: getTimeoutValue().isPositive()
                     CountAndTimeUnit delay = TimeUtils.durationToCountAndTimeUnit(getTimeoutValue());
                     scheduledTimeout = timer.schedule(new TimeoutHandler(), delay.getCount(), delay.getUnit());
                 }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/IdentifyingState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/IdentifyingState.java
@@ -28,6 +28,7 @@ import org.bitrepository.client.conversation.selector.SelectedComponentInfo;
 import org.bitrepository.client.exceptions.UnexpectedResponseException;
 import org.bitrepository.common.exceptions.UnableToFinishException;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -79,9 +80,8 @@ public abstract class IdentifyingState extends GeneralConversationState {
     }
 
     @Override
-    protected long getTimeoutValue() {
-        return getContext().getSettings().getRepositorySettings().getClientSettings().getIdentificationTimeout()
-                .longValue();
+    protected Duration getTimeoutValue() {
+        return getContext().getSettings().getIdentificationTimeout();
     }
 
     /**

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/PerformingOperationState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/PerformingOperationState.java
@@ -26,7 +26,9 @@ import org.bitrepository.bitrepositorymessages.MessageResponse;
 import org.bitrepository.client.conversation.selector.SelectedComponentInfo;
 import org.bitrepository.client.exceptions.UnexpectedResponseException;
 import org.bitrepository.common.exceptions.UnableToFinishException;
+import org.bitrepository.common.utils.TimeUtils;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,14 +81,15 @@ public abstract class PerformingOperationState extends GeneralConversationState 
 
     @Override
     protected void logStateTimeout() throws UnableToFinishException {
-        throw new UnableToFinishException(
-                "Failed to receive responses from all contributors before timeout(" + getTimeoutValue() + "ms). Missing contributors " +
+        throw new UnableToFinishException("Failed to receive responses from all contributors before timeout (" +
+                        TimeUtils.durationToHuman(getTimeoutValue()) +
+                        "). Missing contributors " +
                         getOutstandingComponents());
     }
 
     @Override
-    protected long getTimeoutValue() {
-        return getContext().getSettings().getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+    protected Duration getTimeoutValue() {
+        return getContext().getSettings().getOperationTimeout();
     }
 
     @Override

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/mediator/CollectionBasedConversationMediator.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/mediator/CollectionBasedConversationMediator.java
@@ -51,7 +51,7 @@ public class CollectionBasedConversationMediator implements ConversationMediator
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final Map<String, Conversation> conversations;
     private final Settings settings;
-    private static final Boolean TIMER_IS_DAEMON = true;
+    private static final boolean TIMER_IS_DAEMON = true;
     private static final String NAME_OF_TIMER = "Collection based conversation timer";
     /**
      * The timer used to schedule cleaning of conversations.
@@ -136,10 +136,10 @@ public class CollectionBasedConversationMediator implements ConversationMediator
     }
 
     /**
-     * Will clean out obsolete conversations in each run. An obsolete conversation is a conversation which satisfies on
-     * of the following criterias: <ol>
+     * Will clean out obsolete conversations in each run. An obsolete conversation is a conversation which satisfies ony
+     * of the following criteria: <ol>
      * <li> Returns true for the <code>hasEnded()</code> method.
-     * <li> Is older than the conversationTImeout limit allows.
+     * <li> Is older than the conversationTimeout limit allows.
      * </ol>
      * <p>
      * A copy of the current conversations is created before running through the conversations to avoid having to lock

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/mediator/CollectionBasedConversationMediator.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/mediator/CollectionBasedConversationMediator.java
@@ -96,7 +96,7 @@ public class CollectionBasedConversationMediator implements ConversationMediator
     }
 
     /**
-     * Will try to fail a conversation gracefully. This entitles:
+     * Will try to fail a conversation gracefully. This consists of:
      * <ul>
      * <li> Removing the conversation from the list of conversations.
      * <li> Attempt to call the failConversation operation on the conversation. The call is made in a separate thread to
@@ -136,7 +136,7 @@ public class CollectionBasedConversationMediator implements ConversationMediator
     }
 
     /**
-     * Will clean out obsolete conversations in each run. An obsolete conversation is a conversation which satisfies ony
+     * Will clean out obsolete conversations in each run. An obsolete conversation is a conversation which satisfies any
      * of the following criteria: <ol>
      * <li> Returns true for the <code>hasEnded()</code> method.
      * <li> Is older than the conversationTimeout limit allows.

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/CommandLineClient.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -208,9 +209,8 @@ public abstract class CommandLineClient {
     /**
      * @return The timeout to use for performing the full operation.
      */
-    protected long getTimeout() {
-        return settings.getRepositorySettings().getClientSettings().getIdentificationTimeout().longValue() +
-                settings.getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+    protected Duration getTimeout() {
+        return settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
     }
 
     /**

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/clients/PagingGetChecksumsClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/clients/PagingGetChecksumsClient.java
@@ -30,9 +30,11 @@ import org.bitrepository.commandline.output.OutputHandler;
 import org.bitrepository.commandline.outputformatter.GetChecksumsOutputFormatter;
 import org.bitrepository.commandline.resultmodel.GetChecksumsResultModel;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper class for GetChecksumClient to handle paging through large result sets
@@ -42,13 +44,13 @@ public class PagingGetChecksumsClient {
     private GetChecksumsResultModel model;
     private final GetChecksumsOutputFormatter outputFormatter;
     private final OutputHandler outputHandler;
-    private final long timeout;
+    private final Duration timeout;
     private final int pageSize;
 
-    public PagingGetChecksumsClient(GetChecksumsClient client, long timeout, int pageSize, GetChecksumsOutputFormatter outputFormatter,
+    public PagingGetChecksumsClient(GetChecksumsClient client, Duration timeout, int pageSize, GetChecksumsOutputFormatter outputFormatter,
                                     OutputHandler outputHandler) {
         this.client = client;
-        this.timeout = timeout;
+        this.timeout = Objects.requireNonNull(timeout, "timeout");
         this.pageSize = pageSize;
         this.outputFormatter = outputFormatter;
         this.outputHandler = outputHandler;

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/clients/PagingGetFileIDsClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/clients/PagingGetFileIDsClient.java
@@ -29,9 +29,11 @@ import org.bitrepository.commandline.output.OutputHandler;
 import org.bitrepository.commandline.outputformatter.GetFileIDsOutputFormatter;
 import org.bitrepository.commandline.resultmodel.GetFileIDsResultModel;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper class for GetFileIDsClient to handle paging through large result sets
@@ -41,13 +43,13 @@ public class PagingGetFileIDsClient {
     private GetFileIDsResultModel model;
     private final GetFileIDsOutputFormatter outputFormatter;
     private final OutputHandler outputHandler;
-    private final long timeout;
+    private final Duration timeout;
     private final int pageSize;
 
-    public PagingGetFileIDsClient(GetFileIDsClient client, long timeout, int pageSize, GetFileIDsOutputFormatter outputFormatter,
+    public PagingGetFileIDsClient(GetFileIDsClient client, Duration timeout, int pageSize, GetFileIDsOutputFormatter outputFormatter,
                                   OutputHandler outputHandler) {
         this.client = client;
-        this.timeout = timeout;
+        this.timeout = Objects.requireNonNull(timeout, "timeout");
         this.pageSize = pageSize;
         this.outputFormatter = outputFormatter;
         this.outputHandler = outputHandler;

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/GetChecksumsEventHandler.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/GetChecksumsEventHandler.java
@@ -26,6 +26,8 @@ import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.commandline.output.OutputHandler;
 import org.bitrepository.commandline.resultmodel.GetChecksumsResultModel;
 
+import java.time.Duration;
+
 /**
  * Event handler for paging through GetChecksums results
  */
@@ -33,7 +35,7 @@ public class GetChecksumsEventHandler extends PagingEventHandler {
 
     private final GetChecksumsResultModel model;
 
-    public GetChecksumsEventHandler(GetChecksumsResultModel model, Long timeout, OutputHandler outputHandler) {
+    public GetChecksumsEventHandler(GetChecksumsResultModel model, Duration timeout, OutputHandler outputHandler) {
         super(timeout, outputHandler);
         this.model = model;
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/GetFileIDsEventHandler.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/GetFileIDsEventHandler.java
@@ -26,13 +26,15 @@ import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.commandline.output.OutputHandler;
 import org.bitrepository.commandline.resultmodel.GetFileIDsResultModel;
 
+import java.time.Duration;
+
 /**
  * Event handler for paging through GetFileIDs results
  */
 public class GetFileIDsEventHandler extends PagingEventHandler {
     private final GetFileIDsResultModel model;
 
-    public GetFileIDsEventHandler(GetFileIDsResultModel model, Long timeout, OutputHandler outputHandler) {
+    public GetFileIDsEventHandler(GetFileIDsResultModel model, Duration timeout, OutputHandler outputHandler) {
         super(timeout, outputHandler);
         this.model = model;
     }

--- a/bitrepository-client/src/test/java/org/bitrepository/access/getaudittrails/AuditTrailClientComponentTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/access/getaudittrails/AuditTrailClientComponentTest.java
@@ -46,6 +46,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.math.BigInteger;
 
 import static org.testng.Assert.assertEquals;
@@ -56,9 +58,10 @@ import static org.testng.Assert.assertNotNull;
  */
 public class AuditTrailClientComponentTest extends DefaultClientTest {
     private GetAuditTrailsMessageFactory testMessageFactory;
+    private DatatypeFactory datatypeFactory;
 
     @BeforeMethod(alwaysRun=true)
-    public void beforeMethodSetup() throws Exception {
+    public void beforeMethodSetup() throws DatatypeConfigurationException {
         testMessageFactory = new GetAuditTrailsMessageFactory(settingsForTestClient.getComponentID());
         
         Collection c = settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0);
@@ -71,10 +74,12 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
         settingsForCUT.getRepositorySettings().getCollections().getCollection().add(c);
         
         settingsForCUT.getRepositorySettings().getGetAuditTrailSettings().getNonPillarContributorIDs().clear();
+
+        datatypeFactory = DatatypeFactory.newInstance();
     }
 
     @Test(groups = {"regressiontest"})
-    public void verifyAuditTrailClientFromFactory() throws Exception {
+    public void verifyAuditTrailClientFromFactory() {
         Assert.assertTrue(AccessComponentFactory.getInstance().createAuditTrailClient(
                 settingsForCUT, securityManager, settingsForTestClient.getComponentID())
                 instanceof ConversationBasedAuditTrailClient,
@@ -84,7 +89,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
 
     @Test(groups = {"regressiontest"})
     public void getAllAuditTrailsTest() throws InterruptedException {
-        addDescription("Tests the simplest case of getting all audit trail event for all contributers.");
+        addDescription("Tests the simplest case of getting all audit trail event for all contributors.");
         
         addStep("Create a AuditTrailClient.", "");
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
@@ -92,7 +97,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
 
         addStep("Retrieve all audit trails from the collection by calling with a null componentQueries array",
                 "This should be interpreted as a request for all audit trails from all the collection settings " +
-        "defined contributers.");
+        "defined contributors.");
         client.getAuditTrails(collectionID, null, DEFAULT_FILE_ID, null, testEventHandler, null);
         assertEquals(testEventHandler.waitForEvent().getEventType(),
                 OperationEvent.OperationEventType.IDENTIFY_REQUEST_SENT);
@@ -232,7 +237,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
     @Test(groups = {"regressiontest"})
     public void negativeGetAuditTrailsResponseTest() throws InterruptedException {
         addDescription("Verify that the GetAuditTrail client works correct when receiving a negative " +
-        "GetAuditTrails response from one contributers.");
+        "GetAuditTrails response from one contributors.");
 
         addStep("Create a AuditTrailClient.", "");
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
@@ -240,7 +245,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
 
         addStep("Retrieve all audit trails from the collection by calling with a null componentQueries array",
                 "This should be interpreted as a request for all audit trails from all the collection settings " +
-        "defined contributers.");
+        "defined contributors.");
         client.getAuditTrails(collectionID, null, null, null, testEventHandler, null);
         IdentifyContributorsForGetAuditTrailsRequest identifyRequest =
             collectionReceiver.waitForMessage(IdentifyContributorsForGetAuditTrailsRequest.class);
@@ -314,7 +319,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
 
         addStep("Retrieve all audit trails from the collection by calling with a null componentQueries array",
                 "This should be interpreted as a request for all audit trails from all the collection settings " +
-        "defined contributers.");
+        "defined contributors.");
         client.getAuditTrails(collectionID, null, null, null, testEventHandler, null);
         IdentifyContributorsForGetAuditTrailsRequest identifyRequest =
             collectionReceiver.waitForMessage(IdentifyContributorsForGetAuditTrailsRequest.class);
@@ -376,11 +381,11 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
     @Test(groups = {"regressiontest"})
     public void incompleteSetOfFinalResponsesTest() throws Exception {
         addDescription("Verify that the GetAuditTrail client works correct without receiving responses from all " +
-        "contributers.");
+        "contributors.");
         addStep("Configure 500 ms second timeout for the operation itself. " +
-                "The default 2 contributers collection is used", "");
+                "The default 2 contributors collection is used", "");
 
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(500));
+        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeoutDuration(datatypeFactory.newDuration(500));
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         AuditTrailClient client = createAuditTrailClient();
 
@@ -421,7 +426,7 @@ public class AuditTrailClientComponentTest extends DefaultClientTest {
         addDescription("Tests the the AuditTrailClient handles lack of Final Responses gracefully  ");
         addStep("Set a 100 ms timeout for the operation.", "");
 
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(100));
+        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeoutDuration(datatypeFactory.newDuration(100));
         AuditTrailClient client = createAuditTrailClient();
 
         addStep("Make the client ask for all audit trails.",

--- a/bitrepository-client/src/test/java/org/bitrepository/access/getfile/GetFileClientComponentTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/access/getfile/GetFileClientComponentTest.java
@@ -39,8 +39,11 @@ import org.bitrepository.client.eventhandler.ContributorEvent;
 import org.bitrepository.client.eventhandler.IdentificationCompleteEvent;
 import org.bitrepository.client.eventhandler.OperationEvent.OperationEventType;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.math.BigInteger;
 import java.net.URL;
 
@@ -51,7 +54,14 @@ import static org.testng.Assert.assertEquals;
  */
 public class GetFileClientComponentTest extends AbstractGetFileClientTest {
 
-    private static FilePart NO_FILE_PART = null;
+    private static final FilePart NO_FILE_PART = null;
+
+    private DatatypeFactory datatypeFactory;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUpFactory() throws DatatypeConfigurationException {
+        datatypeFactory = DatatypeFactory.newInstance();
+    }
 
     @Test(groups = {"regressiontest"})
     public void verifyGetFileClientFromFactory() {
@@ -89,7 +99,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         messageBus.sendMessage(identifyResponse1);
 
         addStep("Send a response from pillar2", "A COMPONENT_IDENTIFIED event should be generated for pillar2 " +
-                "followed by a IDENTIFICATION_COMPLETE event. " +
+                "followed by an IDENTIFICATION_COMPLETE event. " +
                 "The client should then proceed to requesting the file from pillar2 by sending a GetFileRequest with " +
                 "the correct and parameters" +
                 "generating a REQUEST_SENT event.");
@@ -154,8 +164,8 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 "A IdentifyPillarsForGetFileRequest will be sent to the pillar.");
         client.getFileFromSpecificPillar(collectionID, DEFAULT_FILE_ID, filePart, httpServerConfiguration.getURL(DEFAULT_FILE_ID),
                 chosenPillar, testEventHandler, null);
-        IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage = null;
-        receivedIdentifyRequestMessage = collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
+        IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage =
+                collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
         addStep("The pillar sends a response to the identify message.",
@@ -215,7 +225,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 "It should be possible to change the values of the configurations.");
 
         addStep("Make the GetClient ask for fastest pillar.",
-                "It should send message to identify which pillars and a IdentifyPillarsRequestSent notification should be generated.");
+                "It should send message to identify which pillars and an IdentifyPillarsRequestSent notification should be generated.");
         client.getFileFromFastestPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
                 httpServerConfiguration.getURL(DEFAULT_FILE_ID),
                 testEventHandler, null);
@@ -266,11 +276,12 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
     public void getFileClientWithIdentifyTimeout() throws Exception {
         addDescription("Verify that the GetFile works correct without receiving responses from all pillars.");
         addFixture("Set the identification timeout to 500ms");
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(500));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(500));
 
 
         addStep("Call getFile form fastest pillar.",
-                "A IDENTIFY_REQUEST_SENT should be generate and a identification request should be sent.");
+                "A IDENTIFY_REQUEST_SENT should be generate and an identification request should be sent.");
         GetFileClient client = createGetFileClient();
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         client.getFileFromFastestPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
@@ -280,7 +291,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
-        addStep("Send a identification response from pillar1.",
+        addStep("Send an identification response from pillar1.",
                 "A COMPONENT_IDENTIFIED event should be generated.");
 
         IdentifyPillarsForGetFileResponse identificationResponse1 = messageFactory.createIdentifyPillarsForGetFileResponse(
@@ -289,7 +300,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.COMPONENT_IDENTIFIED);
 
         addStep("Wait 1 second.",
-                "A IDENTIFY_TIMEOUT event should be generated, followed by a IDENTIFICATION_COMPLETE.");
+                "A IDENTIFY_TIMEOUT event should be generated, followed by an IDENTIFICATION_COMPLETE.");
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_TIMEOUT);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.COMPONENT_FAILED);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFICATION_COMPLETE);
@@ -314,7 +325,8 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         addDescription("Tests the the GetFileClient handles lack of IdentifyPillarResponses gracefully  ");
         addStep("Set a 500 ms timeout for identifying pillar.", "");
 
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(500));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(500));
         GetFileClient client = createGetFileClient();
 
         addStep("Make the GetClient ask for fastest pillar.",
@@ -349,8 +361,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         client.getFileFromSpecificPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
                 httpServerConfiguration.getURL(DEFAULT_FILE_ID),
                 PILLAR1_ID, testEventHandler, null);
-        IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage = null;
-        receivedIdentifyRequestMessage =
+        IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage =
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
@@ -393,7 +404,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
         addStep("The specified pillars sends a FILE_NOT_FOUND response",
-                "The client should generate 1 PillarIdentified event followed by a operation failed event.");
+                "The client should generate 1 PillarIdentified event followed by an operation failed event.");
         IdentifyPillarsForGetFileResponse pillar1Response = messageFactory.createIdentifyPillarsForGetFileResponse(
                 receivedIdentifyRequestMessage, PILLAR1_ID, pillar1DestinationId);
         pillar1Response.getResponseInfo().setResponseCode(ResponseCode.FILE_NOT_FOUND_FAILURE);
@@ -417,7 +428,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         addStep("Use the default 2 pillars.", "");
 
         addStep("Call getFileFromFastestPillar.",
-                "An identify request should be sent and a IdentifyPillarsRequestSent event should be generate");
+                "An identify request should be sent and an IdentifyPillarsRequestSent event should be generate");
         client.getFileFromFastestPillar(collectionID, fileName, NO_FILE_PART, url, testEventHandler, null);
         IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage =
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
@@ -450,7 +461,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         addDescription("Verify that the GetFile works correctly when a checksum pillar respond.");
 
         addStep("Call getFile form fastest pillar.",
-                "A IDENTIFY_REQUEST_SENT should be generate and a identification request should be sent.");
+                "A IDENTIFY_REQUEST_SENT should be generate and an identification request should be sent.");
         GetFileClient client = createGetFileClient();
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         client.getFileFromFastestPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
@@ -460,7 +471,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
-        addStep("Send a identification response from pillar1 with a REQUEST_NOT_SUPPORTED response code.",
+        addStep("Send an identification response from pillar1 with a REQUEST_NOT_SUPPORTED response code.",
                 "No events should be generated.");
 
         IdentifyPillarsForGetFileResponse identificationResponse1 = messageFactory.createIdentifyPillarsForGetFileResponse(
@@ -469,8 +480,8 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         messageBus.sendMessage(identificationResponse1);
         testEventHandler.verifyNoEventsAreReceived();
 
-        addStep("Send a identification response from pillar2 with a IDENTIFICATION_POSITIVE response code .",
-                "A component COMPONENT_IDENTIFIED event shouæd be generated followed by a IDENTIFICATION_COMPLETE.");
+        addStep("Send an identification response from pillar2 with an IDENTIFICATION_POSITIVE response code .",
+                "A component COMPONENT_IDENTIFIED event should be generated followed by an IDENTIFICATION_COMPLETE.");
         IdentifyPillarsForGetFileResponse identificationResponse2 = messageFactory.createIdentifyPillarsForGetFileResponse(
                 receivedIdentifyRequestMessage, PILLAR2_ID, pillar2DestinationId);
         messageBus.sendMessage(identificationResponse2);
@@ -497,7 +508,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 "during the identify phase.");
 
         addStep("Call getFile from the fastest pillar.",
-                "A IDENTIFY_REQUEST_SENT should be generate and a identification request should be sent.");
+                "A IDENTIFY_REQUEST_SENT should be generate and an identification request should be sent.");
         GetFileClient client = createGetFileClient();
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         client.getFileFromFastestPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
@@ -507,7 +518,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.IDENTIFY_REQUEST_SENT);
 
-        addStep("Send a identification response from pillar1 with a IDENTIFICATION_NEGATIVE response code .",
+        addStep("Send an identification response from pillar1 with an IDENTIFICATION_NEGATIVE response code .",
                 "No events should be generated.");
 
         IdentifyPillarsForGetFileResponse identificationResponse1 = messageFactory.createIdentifyPillarsForGetFileResponse(
@@ -516,8 +527,8 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         messageBus.sendMessage(identificationResponse1);
         assertEquals(testEventHandler.waitForEvent().getEventType(), OperationEventType.COMPONENT_FAILED);
 
-        addStep("Send a identification response from pillar2 with a IDENTIFICATION_POSITIVE response code .",
-                "A component COMPONENT_IDENTIFIED event shouæd be generated followed by a IDENTIFICATION_COMPLETE.");
+        addStep("Send an identification response from pillar2 with an IDENTIFICATION_POSITIVE response code .",
+                "A component COMPONENT_IDENTIFIED event should be generated followed by an IDENTIFICATION_COMPLETE.");
         IdentifyPillarsForGetFileResponse identificationResponse2 = messageFactory.createIdentifyPillarsForGetFileResponse(
                 receivedIdentifyRequestMessage, PILLAR2_ID, pillar2DestinationId);
         messageBus.sendMessage(identificationResponse2);
@@ -544,7 +555,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
                 "during the performing phase.");
 
         addStep("Request a getFile from the fastest pillar.",
-                "A IDENTIFY_REQUEST_SENT should be generate and a identification request should be sent.");
+                "A IDENTIFY_REQUEST_SENT should be generate and an identification request should be sent.");
         GetFileClient client = createGetFileClient();
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         client.getFileFromFastestPillar(collectionID, DEFAULT_FILE_ID, NO_FILE_PART,
@@ -553,7 +564,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         IdentifyPillarsForGetFileRequest receivedIdentifyRequestMessage =
                 collectionReceiver.waitForMessage(IdentifyPillarsForGetFileRequest.class);
 
-        addStep("Send a identification response from pillar1 and pillar2 with pillar1 the fastest.",
+        addStep("Send an identification response from pillar1 and pillar2 with pillar1 the fastest.",
                 "Pillar1 should be selected and a GetFileRequest should be sent.");
         IdentifyPillarsForGetFileResponse identificationResponse1 = messageFactory.createIdentifyPillarsForGetFileResponse(
                 receivedIdentifyRequestMessage, PILLAR1_ID, pillar1DestinationId);
@@ -605,7 +616,7 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
         assertEquals(receivedIdentifyRequestMessage.getCollectionID(), otherCollection);
 
         addStep("Send an identification response from pillar2.",
-                "An COMPONENT_IDENTIFIED event should be generate folled by a IDENTIFICATION_COMPLETE and a " +
+                "An COMPONENT_IDENTIFIED event should be generate followed by an IDENTIFICATION_COMPLETE and a " +
                         "REQUEST_SENT. A GetFileIdsFileRequest should be sent to pillar2");
         messageBus.sendMessage(messageFactory.createIdentifyPillarsForGetFileResponse(
                 receivedIdentifyRequestMessage, PILLAR2_ID, pillar2DestinationId));
@@ -632,7 +643,9 @@ public class GetFileClientComponentTest extends AbstractGetFileClientTest {
      * @return A new GetFileClient(Wrapper).
      */
     private GetFileClient createGetFileClient() {
-        return new GetFileClientTestWrapper(new ConversationBasedGetFileClient(
-                messageBus, conversationMediator, settingsForCUT, settingsForTestClient.getComponentID()), testEventManager);
+        return new GetFileClientTestWrapper(
+                new ConversationBasedGetFileClient(messageBus, conversationMediator, settingsForCUT,
+                        settingsForTestClient.getComponentID()),
+                testEventManager);
     }
 }

--- a/bitrepository-client/src/test/java/org/bitrepository/access/getstatus/GetStatusClientComponentTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/access/getstatus/GetStatusClientComponentTest.java
@@ -40,7 +40,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.math.BigInteger;
+import javax.xml.datatype.DatatypeFactory;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
@@ -50,20 +50,20 @@ public class GetStatusClientComponentTest extends DefaultFixtureClientTest {
         private TestGetStatusMessageFactory testMessageFactory;
 
         @BeforeMethod(alwaysRun=true)
-        public void beforeMethodSetup() throws Exception {
+        public void beforeMethodSetup() {
             testMessageFactory = new TestGetStatusMessageFactory(settingsForTestClient.getComponentID());
 
             if (settingsForCUT.getRepositorySettings().getGetStatusSettings() == null) {
                 settingsForCUT.getRepositorySettings().setGetStatusSettings(new GetStatusSettings());
             }
-            List<String> contributers = settingsForCUT.getRepositorySettings().getGetStatusSettings().getNonPillarContributorIDs();
-            contributers.clear();
-            contributers.add(PILLAR1_ID);
-            contributers.add(PILLAR2_ID);
+            List<String> contributors = settingsForCUT.getRepositorySettings().getGetStatusSettings().getNonPillarContributorIDs();
+            contributors.clear();
+            contributors.add(PILLAR1_ID);
+            contributors.add(PILLAR2_ID);
         }
 
         @Test(groups = {"regressiontest"})
-        public void verifyGetStatusClientFromFactory() throws Exception {
+        public void verifyGetStatusClientFromFactory() {
             Assert.assertTrue(AccessComponentFactory.getInstance().createGetStatusClient(
                     settingsForCUT, securityManager, settingsForTestClient.getComponentID())
                     instanceof ConversationBasedGetStatusClient,
@@ -74,11 +74,13 @@ public class GetStatusClientComponentTest extends DefaultFixtureClientTest {
         @Test(groups = {"regressiontest"})
         public void incompleteSetOfIdendifyResponses() throws Exception {
             addDescription("Verify that the GetStatus client works correct without receiving responses from all " +
-                    "contributers.");
-            addStep("Configure 1 second timeout for identifying contributers. " +
-                    "The default 2 contributers collection is used", "");
+                    "contributors.");
+            addStep("Configure 1 second timeout for identifying contributors. " +
+                    "The default 2 contributors collection is used", "");
 
-            settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(1000));
+            DatatypeFactory datatypeFactory = DatatypeFactory.newInstance();
+            settingsForCUT.getRepositorySettings().getClientSettings()
+                    .setIdentificationTimeoutDuration(datatypeFactory.newDuration(1000));
             TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
             GetStatusClient client = createGetStatusClient();
 
@@ -113,7 +115,7 @@ public class GetStatusClientComponentTest extends DefaultFixtureClientTest {
         
         @Test(groups = {"regressiontest"})
         public void getAllStatuses() throws InterruptedException {
-            addDescription("Tests the simplest case of getting status for all contributers.");
+            addDescription("Tests the simplest case of getting status for all contributors.");
 
             addStep("Create a GetStatusClient.", "");
             TestEventHandler testEventHandler = new TestEventHandler(testEventManager);

--- a/bitrepository-client/src/test/java/org/bitrepository/client/DefaultClientTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/client/DefaultClientTest.java
@@ -27,8 +27,11 @@ import org.bitrepository.bitrepositorymessages.MessageResponse;
 import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.client.eventhandler.OperationEvent.OperationEventType;
 import org.bitrepository.protocol.bus.MessageReceiver;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.math.BigInteger;
 
 import static org.testng.Assert.assertEquals;
@@ -40,6 +43,12 @@ import static org.testng.Assert.assertNotNull;
  */
 public abstract class DefaultClientTest extends DefaultFixtureClientTest {
     protected final TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
+    private DatatypeFactory datatypeFactory;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUpFactory() throws DatatypeConfigurationException {
+        datatypeFactory = DatatypeFactory.newInstance();
+    }
 
     @Test(groups = {"regressiontest"})
     public void identificationNegativeTest() throws Exception {
@@ -129,7 +138,8 @@ public abstract class DefaultClientTest extends DefaultFixtureClientTest {
         addDescription("Verify that the client works correct without receiving identification responses from all " +
                 "contributors.");
         addFixture("Set the a identification timeout to 100 ms.");
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(100));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(100));
 
         addStep("Start the operation.",
                 "A IDENTIFY_REQUEST_SENT should be generate and a identification request should be sent.");
@@ -170,7 +180,8 @@ public abstract class DefaultClientTest extends DefaultFixtureClientTest {
                 "More concrete this means that the occurrence of a identification timeout should be handled correctly");
 
         addStep("Set a 100 ms timeout for identifying contributors.", "");
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(100));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(100));
 
         addStep("Start the operation.", "A IDENTIFY_REQUEST_SENT event should be generated.");
         startOperation(testEventHandler);
@@ -189,7 +200,8 @@ public abstract class DefaultClientTest extends DefaultFixtureClientTest {
         addDescription("Tests the the client handles lack of final responses gracefully.");
 
         addStep("Set a 100 ms operation timeout.", "");
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(100));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setOperationTimeoutDuration(datatypeFactory.newDuration(100));
 
         addStep("Start the operation",
                 "A IDENTIFY_REQUEST_SENT event should be received.");
@@ -222,7 +234,8 @@ public abstract class DefaultClientTest extends DefaultFixtureClientTest {
         addDescription("Tests the the client provides collectionID in events.");
 
         addStep("Set a 0.5 second operation timeout.", "");
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(500));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setOperationTimeoutDuration(datatypeFactory.newDuration(500));
 
         addStep("Start the operation", "A IDENTIFY_REQUEST_SENT event should be received.");
         startOperation(testEventHandler);

--- a/bitrepository-client/src/test/java/org/bitrepository/modify/deletefile/DeleteFileClientComponentTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/modify/deletefile/DeleteFileClientComponentTest.java
@@ -45,15 +45,17 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.math.BigInteger;
+import javax.xml.datatype.DatatypeFactory;
 import java.nio.charset.StandardCharsets;
 
 public class DeleteFileClientComponentTest extends DefaultFixtureClientTest {
     private TestDeleteFileMessageFactory messageFactory;
+    private DatatypeFactory datatypeFactory;
 
     @BeforeMethod(alwaysRun=true)
     public void initialise() throws Exception {
         messageFactory = new TestDeleteFileMessageFactory(collectionID);
+        datatypeFactory = DatatypeFactory.newInstance();
     }
 
     @Test(groups={"regressiontest"})
@@ -94,8 +96,7 @@ public class DeleteFileClientComponentTest extends DefaultFixtureClientTest {
                 testEventHandler,
                 null);
 
-        IdentifyPillarsForDeleteFileRequest receivedIdentifyRequestMessage = null;
-        receivedIdentifyRequestMessage = collectionReceiver.waitForMessage(
+        IdentifyPillarsForDeleteFileRequest receivedIdentifyRequestMessage = collectionReceiver.waitForMessage(
                 IdentifyPillarsForDeleteFileRequest.class);
         Assert.assertEquals(receivedIdentifyRequestMessage.getCollectionID(), collectionID);
         Assert.assertNotNull(receivedIdentifyRequestMessage.getCorrelationID());
@@ -193,7 +194,8 @@ public class DeleteFileClientComponentTest extends DefaultFixtureClientTest {
 
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().clear();
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR1_ID);
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(1000L));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(1000));
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         DeleteFileClient deleteClient = createDeleteFileClient();
 
@@ -231,7 +233,8 @@ public class DeleteFileClientComponentTest extends DefaultFixtureClientTest {
 
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().clear();
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR1_ID);
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(100L));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setOperationTimeoutDuration(datatypeFactory.newDuration(100));
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         DeleteFileClient deleteClient = createDeleteFileClient();
 

--- a/bitrepository-client/src/test/java/org/bitrepository/modify/replacefile/ReplaceFileClientComponentTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/modify/replacefile/ReplaceFileClientComponentTest.java
@@ -45,7 +45,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.math.BigInteger;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -54,13 +55,15 @@ public class ReplaceFileClientComponentTest extends DefaultFixtureClientTest {
     private ChecksumDataForFileTYPE DEFAULT_OLD_CHECKSUM_DATA;
     private ChecksumDataForFileTYPE DEFAULT_NEW_CHECKSUM_DATA;
     private TestReplaceFileMessageFactory messageFactory;
+    private DatatypeFactory datatypeFactory;
 
     @BeforeMethod(alwaysRun = true)
-    public void initialise() throws Exception {
+    public void initialise() throws DatatypeConfigurationException {
         messageFactory = new TestReplaceFileMessageFactory(settingsForTestClient.getComponentID());
         DEFAULT_CHECKSUM_SPEC = ChecksumUtils.getDefault(settingsForCUT);
         DEFAULT_OLD_CHECKSUM_DATA = createChecksumData("123checksum321");
         DEFAULT_NEW_CHECKSUM_DATA = createChecksumData("123checksum321");
+        datatypeFactory = DatatypeFactory.newInstance();
     }
 
     @Test(groups = {"regressiontest"})
@@ -156,7 +159,8 @@ public class ReplaceFileClientComponentTest extends DefaultFixtureClientTest {
                 "Should be OK.");
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().clear();
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR1_ID);
-        settingsForCUT.getRepositorySettings().getClientSettings().setIdentificationTimeout(BigInteger.valueOf(100L));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setIdentificationTimeoutDuration(datatypeFactory.newDuration(100));
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         ReplaceFileClient replaceClient = createReplaceFileClient();
         ChecksumSpecTYPE checksumRequest = new ChecksumSpecTYPE();
@@ -187,7 +191,8 @@ public class ReplaceFileClientComponentTest extends DefaultFixtureClientTest {
                 "Should be OK.");
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().clear();
         settingsForCUT.getRepositorySettings().getCollections().getCollection().get(0).getPillarIDs().getPillarID().add(PILLAR1_ID);
-        settingsForCUT.getRepositorySettings().getClientSettings().setOperationTimeout(BigInteger.valueOf(100L));
+        settingsForCUT.getRepositorySettings().getClientSettings()
+                .setOperationTimeoutDuration(datatypeFactory.newDuration(100));
         TestEventHandler testEventHandler = new TestEventHandler(testEventManager);
         ReplaceFileClient replaceClient = createReplaceFileClient();
 

--- a/bitrepository-core/pom.xml
+++ b/bitrepository-core/pom.xml
@@ -17,12 +17,12 @@
     </dependency>
     <dependency>
       <groupId>org.bitrepository.repository-settings</groupId>
-      <artifactId>bitrepository-repository-settings-xsd</artifactId>
+      <artifactId>repository-settings-xsd</artifactId>
       <version>${repository.settings.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitrepository.repository-settings</groupId>
-      <artifactId>bitrepository-repository-settings-java</artifactId>
+      <artifactId>repository-settings-java</artifactId>
       <version>${repository.settings.version}</version>
     </dependency>
     <dependency>

--- a/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
@@ -130,7 +130,6 @@ public class Settings {
 
     static Duration getDurationFromXmlDurationOrMillis(
             javax.xml.datatype.Duration xmlDuration, BigInteger millis) {
-        // Prefer the XML Duration
         if (xmlDuration != null) {
             validateNonNegative(xmlDuration);
             return xmlDurationToDuration(xmlDuration);

--- a/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
@@ -39,9 +39,8 @@ import java.util.List;
 
 /**
  * Contains the general configuration to be used by reference code components. Provides access to both
- * {@link ReferenceSettings} and {@link org.bitrepository.settings.repositorysettings.RepositorySettings}. Use a {@link SettingsProvider}
- * to access settings create
- * <code>Settings</code> objects.
+ * {@link ReferenceSettings} and {@link org.bitrepository.settings.repositorysettings.RepositorySettings}.
+ * Use a {@link SettingsProvider} to access settings create <code>Settings</code> objects.
  */
 public class Settings {
     public static final BigInteger MILLIS_PER_SECOND = BigInteger.valueOf(Duration.ofSeconds(1).toMillis());
@@ -105,14 +104,15 @@ public class Settings {
 
     /**
      * Wraps the {@link org.bitrepository.settings.repositorysettings.ClientSettings#getIdentificationTimeout()}
-     * and {@link ClientSettings#getIdentificationTimeoutDuration()} ()} methods, preferring to use the latter.
+     * and {@link org.bitrepository.settings.repositorysettings.ClientSettings#getIdentificationTimeoutDuration()}
+     * methods, preferring to use the latter.
      *
      * @return the timeout
-     * @see ClientSettings#getIdentificationTimeoutDuration()
+     * @see org.bitrepository.settings.repositorysettings.ClientSettings#getIdentificationTimeoutDuration()
      */
     public Duration getIdentificationTimeout() {
-        // TODO Ole V. Once the old IdentificationTimeout settings in milliseconds is done away with,
-        // TODO the following code gets simpler
+        // TODO Once the old IdentificationTimeout settings in milliseconds is done away with
+        //  the following code gets simpler
         javax.xml.datatype.Duration xmlDuration =
                 getRepositorySettings().getClientSettings().getIdentificationTimeoutDuration();
         BigInteger identificationTimeoutMillis =

--- a/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/settings/Settings.java
@@ -148,7 +148,7 @@ public class Settings {
     /**
      * Converts a javax.xml.datatype.Duration to a java.time.Duration using estimated values for days, months and years.
      */
-    public static Duration xmlDurationToDuration(javax.xml.datatype.Duration xmlDuration) {
+    static Duration xmlDurationToDuration(javax.xml.datatype.Duration xmlDuration) {
         return unitsToDuration(xmlDuration.getField(DatatypeConstants.YEARS), ChronoUnit.YEARS)
                 .plus(unitsToDuration(xmlDuration.getField(DatatypeConstants.MONTHS), ChronoUnit.MONTHS))
                 .plus(unitsToDuration(xmlDuration.getField(DatatypeConstants.DAYS), ChronoUnit.DAYS))

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
@@ -1,0 +1,35 @@
+package org.bitrepository.common.utils;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class CountAndTimeUnit {
+    private final long count;
+    private final TimeUnit unit;
+
+    public CountAndTimeUnit(long count, TimeUnit unit) {
+        this.count = count;
+        this.unit = Objects.requireNonNull(unit, "unit");
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public TimeUnit getUnit() {
+        return unit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CountAndTimeUnit that = (CountAndTimeUnit) o;
+        return count == that.count && unit == that.unit;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, unit);
+    }
+}

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/TimeUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/TimeUtils.java
@@ -24,8 +24,10 @@ package org.bitrepository.common.utils;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Util class to handle the presentation of time in a human-readable form
@@ -123,6 +125,47 @@ public final class TimeUtils {
         return sb.toString();
     }
 
+    /**
+     * @throws ArithmeticException if dur is negative by more than Long.MAX_VALUE seconds
+     */
+    public static String durationToHuman(Duration dur) {
+        if (dur.isZero()) {
+            return "0 ms";
+        }
+
+        List<String> parts = new ArrayList<>(5);
+
+        if (dur.isNegative()) {
+            parts.add("minus");
+            dur = dur.negated();
+        }
+
+        if (dur.toDays() > 0) {
+            parts.add("" + dur.toDays() + "d");
+        }
+        if (dur.toHoursPart() > 0) {
+            parts.add("" + dur.toHoursPart() + "h");
+        }
+        if (dur.toMinutesPart() > 0) {
+            parts.add("" + dur.toMinutesPart() + "m");
+        }
+        if (dur.toSecondsPart() > 0) {
+            parts.add("" + dur.toSecondsPart() + "s");
+        }
+        if (dur.toNanosPart() > 0) {
+            // If the fraction of second is a whole number of millis, print as such; otherwise print only as nanos
+            Duration fraction = Duration.ofNanos(dur.getNano());
+            Duration remainderAfterMillis = fraction.minusMillis(fraction.toMillisPart());
+            if (remainderAfterMillis.isZero()) {
+                parts.add("" + fraction.toMillisPart() + " ms");
+            } else {
+                parts.add("" + fraction.toNanosPart() + " ns");
+            }
+        }
+
+        return String.join(" ", parts);
+    }
+
     public static String shortDate(Date date) {
         return formatter.format(date);
     }
@@ -145,4 +188,32 @@ public final class TimeUtils {
             return currentMax;
         }
     }
+
+    /**
+     *
+     * @param duration a non-negative duration
+     * @return the duration converted to a long in either SECONDS, MILLISECONDS, MICROSECONDS or NANOSECONDS
+     * maintaining the best possible precision and truncated if necessary.
+     * @throws IllegalArgumentException if duration is negative
+     */
+    public static CountAndTimeUnit durationToCountAndTimeUnit(Duration duration) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("duration must be 0 or positive, was " + duration);
+        }
+
+        if (duration.compareTo(Duration.ofNanos(Long.MAX_VALUE)) <= 0) { // fits in nanos
+            return new CountAndTimeUnit(duration.toNanos(), TimeUnit.NANOSECONDS);
+        }
+        if (duration.compareTo(Duration.of(Long.MAX_VALUE, ChronoUnit.MICROS)) <= 0) { // fits in micros
+            return new CountAndTimeUnit(duration.dividedBy(ChronoUnit.MICROS.getDuration()), TimeUnit.MICROSECONDS);
+        }
+        if (duration.compareTo(Duration.ofMillis(Long.MAX_VALUE)) <= 0) { // fits in millis
+            return new CountAndTimeUnit(duration.toMillis(), TimeUnit.MILLISECONDS);
+        }
+        if (duration.compareTo(Duration.ofSeconds(Long.MAX_VALUE)) <= 0) { // fits in seconds
+            return new CountAndTimeUnit(duration.toSeconds(), TimeUnit.SECONDS);
+        }
+        return new CountAndTimeUnit(duration.toMinutes(), TimeUnit.MINUTES);
+    }
+
 }

--- a/bitrepository-core/src/main/resources/examples/settings/RepositorySettings.xml
+++ b/bitrepository-core/src/main/resources/examples/settings/RepositorySettings.xml
@@ -76,7 +76,7 @@
     -->
     <CollectionDestination>topic://dummy-repository-id</CollectionDestination>
     <!-- 
-      AlarmDestination, defines the destination to where alarms are send. This should be a topic, 
+      AlarmDestination, defines the destination to where alarms are sent. This should be a topic,
       so that multiple components interested in receiving alarms won't steal them from each other. 
     -->
     <AlarmDestination>topic://dummy-repository-id.alarms</AlarmDestination>
@@ -95,17 +95,21 @@
   <!-- General settings for the various clients -->
   <ClientSettings>
     <!-- 
-      IdentificationTimeout, the maximum time which clients should wait for identify* responses during
+      IdentificationTimeoutDuration, the maximum time which clients should wait for identify* responses during
       the identification phase of an operation. 
-      Unit in milliseconds. 
+      A non-negative XML durations consisting of hours, minutes and/or seconds.
+      The seconds may have up to 9 decimals of fraction.
+      For example PT2H (2 hours), PT3M (3 minutes), PT1H22M22.5S (1 hour 22 minutes 22.5 seconds).
     -->
-    <IdentificationTimeout>10000</IdentificationTimeout>
+    <IdentificationTimeoutDuration>PT10S</IdentificationTimeoutDuration>
     <!-- 
       OperationTimeout, the maximum time which clients should wait for an operation to finish after 
       an successful identification phase. 
-      Unit in milliseconds. 
+      A non-negative XML durations consisting of hours, minutes and/or seconds.
+      The seconds may have up to 9 decimals of fraction.
+      For example PT2H (2 hours), PT3M (3 minutes), PT1H22M22.5S (1 hour 22 minutes 22.5 seconds).
     -->
-    <OperationTimeout>3600000</OperationTimeout>
+    <OperationTimeoutDuration>PT1H</OperationTimeoutDuration>
   </ClientSettings>
 
   <!-- 

--- a/bitrepository-core/src/test/java/org/bitrepository/common/settings/SettingsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/settings/SettingsTest.java
@@ -1,0 +1,113 @@
+package org.bitrepository.common.settings;
+
+import org.jaccept.structure.ExtendedTestCase;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import java.math.BigInteger;
+import java.time.Duration;
+
+public class SettingsTest extends ExtendedTestCase {
+
+    private DatatypeFactory factory;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUpFactory() throws DatatypeConfigurationException {
+        factory = DatatypeFactory.newInstance();
+    }
+
+    @Test(groups = {"regressiontest"}, expectedExceptions = NullPointerException.class)
+    public void getDurationFromXmlDurationOrMillisRequiresOneNonNullArg() {
+        addDescription("Tests that getDurationFromXmlDurationOrMillis() fails when given two nulls");
+        addStep("null and null", "NPE");
+
+        Settings.getDurationFromXmlDurationOrMillis(null, null);
+    }
+
+
+    @Test(groups = {"regressiontest"})
+    public void testGetDurationFromXmlDurationOrMillis() {
+        addDescription("Tests conversions and selection by getDurationFromXmlDurationOrMillis()");
+
+        addStep("null and some milliseconds", "Duration of millis");
+        Assert.assertEquals(Settings.getDurationFromXmlDurationOrMillis(null, BigInteger.valueOf(54321)),
+                Duration.ofMillis(54321));
+
+        addStep("XML duration and null", "XML duration converted");
+        Assert.assertEquals(
+                Settings.getDurationFromXmlDurationOrMillis(
+                        factory.newDuration("PT7M"), null),
+                Duration.ofMinutes(7));
+
+        addStep("Conflicting XML duration and millis", "XML duration should be preferred");
+        Assert.assertEquals(
+                Settings.getDurationFromXmlDurationOrMillis(
+                        factory.newDuration("PT2M"), BigInteger.valueOf(13)),
+                Duration.ofMinutes(2));
+    }
+
+        @Test(groups = {"regressiontest"}, expectedExceptions = IllegalArgumentException.class)
+    public void negativeDurationIsRejected() {
+        Settings.validateNonNegative(factory.newDuration("-PT0.00001S"));
+    }
+
+    @Test(groups = {"regressiontest"})
+    public void testXmlDurationToDuration() {
+        addDescription("Tests xmlDurationToDuration in sunshine scenario cases");
+
+        addStep("Test correct and precise conversion",
+                "Hours, minutes and seconds are converted with full precision");
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT3S")),
+                Duration.ofSeconds(3));
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT3.3S")),
+                Duration.ofSeconds(3, 300_000_000));
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT3.000000003S")),
+                Duration.ofSeconds(3, 3));
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT3.123456789S")),
+                Duration.ofSeconds(3, 123_456_789));
+
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT4M")),
+                Duration.ofMinutes(4));
+
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT5H")),
+                Duration.ofHours(5));
+
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("PT6H7M8.9S")),
+                Duration.ofHours(6).plusMinutes(7).plusSeconds(8).plusMillis(900));
+
+        addStep("Test approximate conversion",
+                "Days, months and years are converted using estimated factors");
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("P2D")),
+                Duration.ofDays(2));
+        Assert.assertEquals(Settings.xmlDurationToDuration(factory.newDuration("P3DT4M")),
+                Duration.ofDays(3).plusMinutes(4));
+
+        // We require a month to be between 28 and 31 days exclusive
+        Duration minMonthLengthExclusive = Duration.ofDays(28);
+        Duration maxMonthLengthExclusive = Duration.ofDays(31);
+        Duration convertedMonth = Settings.xmlDurationToDuration(factory.newDuration("P1M"));
+        assertBetweenExclusive(convertedMonth, minMonthLengthExclusive, maxMonthLengthExclusive);
+
+        // Two years is between 730 and 731 days
+        Duration minTwoYearsLengthExclusive = Duration.ofDays(2 * 365);
+        Duration maxTwoYearsLengthExclusive = Duration.ofDays(2 * 365 + 1);
+        Duration convertedTwoYears = Settings.xmlDurationToDuration(factory.newDuration("P2Y"));
+        assertBetweenExclusive(convertedTwoYears, minTwoYearsLengthExclusive, maxTwoYearsLengthExclusive);
+    }
+
+    private static <T extends Comparable<T>> void assertBetweenExclusive(T actual, T minExclusive, T maxExclusive) {
+        Assert.assertTrue(actual.compareTo(minExclusive) > 0);
+        Assert.assertTrue(actual.compareTo(maxExclusive) < 0);
+    }
+
+    @Test(groups = {"regressiontest"}, expectedExceptions = ArithmeticException.class)
+    public void tooManyDecimalsAreRejected() {
+        addDescription("Tests that xmlDurationToDuration() rejects more than 9 decimals on seconds");
+        addStep("Duration with 10 decimals, PT2.0123456789S", "ArithmeticException");
+        Settings.xmlDurationToDuration(factory.newDuration("PT2.0123456789S"));
+    }
+
+}

--- a/bitrepository-core/src/test/resources/settings/xml/bitrepository-devel/RepositorySettings.xml
+++ b/bitrepository-core/src/test/resources/settings/xml/bitrepository-devel/RepositorySettings.xml
@@ -50,8 +50,8 @@
   </ProtocolSettings>
   
   <ClientSettings>
-    <IdentificationTimeout>60000</IdentificationTimeout>
-    <OperationTimeout>60000</OperationTimeout>
+    <IdentificationTimeoutDuration>PT1M</IdentificationTimeoutDuration>
+    <OperationTimeoutDuration>PT1M</OperationTimeoutDuration>
   </ClientSettings>
 
   <GetAuditTrailSettings>

--- a/bitrepository-integration/src/main/resources/quickstart/conf/RepositorySettings.xml
+++ b/bitrepository-integration/src/main/resources/quickstart/conf/RepositorySettings.xml
@@ -62,8 +62,8 @@
     </MessageBusConfiguration>
   </ProtocolSettings>
   <ClientSettings>
-    <IdentificationTimeout>180000</IdentificationTimeout>
-    <OperationTimeout>3600000</OperationTimeout>
+    <IdentificationTimeoutDuration>PT3M</IdentificationTimeoutDuration>
+    <OperationTimeoutDuration>PT1H</OperationTimeoutDuration>
   </ClientSettings>
   <PillarSettings/>
   <DeleteFileSettings/>

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityCollectorEventHandler.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityCollectorEventHandler.java
@@ -27,11 +27,15 @@ import org.bitrepository.client.eventhandler.ContributorFailedEvent;
 import org.bitrepository.client.eventhandler.EventHandler;
 import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.client.eventhandler.OperationEvent.OperationEventType;
+import org.bitrepository.common.utils.CountAndTimeUnit;
+import org.bitrepository.common.utils.TimeUtils;
 import org.bitrepository.integrityservice.cache.IntegrityModel;
 import org.bitrepository.integrityservice.workflow.IntegrityContributors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -44,18 +48,18 @@ import java.util.concurrent.TimeUnit;
 public class IntegrityCollectorEventHandler implements EventHandler {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final IntegrityModel store;
-    private final long timeout;
+    private final Duration timeout;
     private final BlockingQueue<OperationEvent> finalEventQueue = new LinkedBlockingQueue<>();
     private final IntegrityContributors integrityContributors;
 
     /**
      * @param model                 The integrity model, where the results of GetChecksums or GetFileIDs are to be delivered.
-     * @param timeout               The maximum amount of millisecond to wait for an result.
+     * @param timeout               The maximum duration to wait for a result.
      * @param integrityContributors the integrity contributors
      */
-    public IntegrityCollectorEventHandler(IntegrityModel model, long timeout, IntegrityContributors integrityContributors) {
+    public IntegrityCollectorEventHandler(IntegrityModel model, Duration timeout, IntegrityContributors integrityContributors) {
         this.store = model;
-        this.timeout = timeout;
+        this.timeout = Objects.requireNonNull(timeout, "timeout");
         this.integrityContributors = integrityContributors;
     }
 
@@ -80,14 +84,15 @@ public class IntegrityCollectorEventHandler implements EventHandler {
     }
 
     /**
-     * Retrieves the final event when the operation finishes. The final event is awaited for 'timeout' amount
-     * of milliseconds. If no final events has occurred, then an InterruptedException is thrown.
+     * Retrieves the final event when the operation finishes.
+     * The final event is awaited for 'timeout'. If no final events has occurred, then null is returned.
      *
-     * @return The final event.
-     * @throws InterruptedException If it timeouts before the final event.
+     * @return The final event or null if no final events has occurred.
+     * @throws InterruptedException If interrupted while waiting.
      */
     public OperationEvent getFinish() throws InterruptedException {
-        return finalEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+        CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
+        return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
     }
 
     /**

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
@@ -71,7 +71,7 @@ public class IntegrityEventCompleteAwaiter implements EventHandler {
 
     /**
      * Retrieves the final event when the operation finishes. The final event is awaited for 'timeout' amount
-     * of milliseconds. If no final events has occurred, then an InterruptedException is thrown.
+     * of milliseconds. If no final events has occurred, null is returned.
      *
      * @return The final event.
      */

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
@@ -25,12 +25,14 @@ import org.bitrepository.client.eventhandler.EventHandler;
 import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.client.eventhandler.OperationEvent.OperationEventType;
 import org.bitrepository.common.settings.Settings;
+import org.bitrepository.common.utils.CountAndTimeUnit;
+import org.bitrepository.common.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
  * EventHandler for awaiting an operation to be complete.
@@ -41,7 +43,7 @@ public class IntegrityEventCompleteAwaiter implements EventHandler {
     /**
      * The amount of milliseconds before the results are required.
      */
-    private final Long timeout;
+    private final Duration timeout;
 
     /**
      * The queue used to store the received operation events.
@@ -54,8 +56,7 @@ public class IntegrityEventCompleteAwaiter implements EventHandler {
      * @param settings The settings.
      */
     public IntegrityEventCompleteAwaiter(Settings settings) {
-        this.timeout = settings.getRepositorySettings().getClientSettings().getIdentificationTimeout().longValue()
-                + settings.getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+        this.timeout = settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
     }
 
     @Override
@@ -77,7 +78,8 @@ public class IntegrityEventCompleteAwaiter implements EventHandler {
      */
     public OperationEvent getFinish() {
         try {
-            return finalEventQueue.poll(timeout, TimeUnit.MILLISECONDS);
+            CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
+            return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
         } catch (InterruptedException e) {
             throw new IllegalStateException("Interrupted while waiting for the final response.", e);
         }

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/GetChecksumForFileStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/GetChecksumForFileStep.java
@@ -37,6 +37,7 @@ import org.bitrepository.service.workflow.AbstractWorkFlowStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +50,7 @@ public class GetChecksumForFileStep extends AbstractWorkFlowStep {
     private final IntegrityInformationCollector collector;
     private final ChecksumSpecTYPE checksumType;
     private final IntegrityAlerter alerter;
-    private final Long timeout;
+    private final Duration timeout;
     protected final String fileID;
     protected final String collectionID;
     private final IntegrityContributors integrityContributors;
@@ -72,8 +73,7 @@ public class GetChecksumForFileStep extends AbstractWorkFlowStep {
         this.collectionID = collectionID;
         this.fileID = fileID;
         this.integrityContributors = integrityContributors;
-        this.timeout = settings.getRepositorySettings().getClientSettings().getIdentificationTimeout().longValue() +
-                settings.getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+        this.timeout = settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
     }
 
     @Override

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/UpdateChecksumsStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/UpdateChecksumsStep.java
@@ -38,6 +38,7 @@ import org.bitrepository.service.workflow.AbstractWorkFlowStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -53,7 +54,7 @@ public abstract class UpdateChecksumsStep extends AbstractWorkFlowStep {
     protected final IntegrityModel store;
     private final ChecksumSpecTYPE checksumType;
     private final IntegrityAlerter alerter;
-    private final Long timeout;
+    private final Duration timeout;
     private final Integer maxNumberOfResultsPerConversation;
     protected final String collectionID;
     private boolean abortInCaseOfFailure = true;
@@ -74,8 +75,7 @@ public abstract class UpdateChecksumsStep extends AbstractWorkFlowStep {
         this.alerter = alerter;
         this.collectionID = collectionID;
         this.integrityContributors = integrityContributors;
-        this.timeout = settings.getRepositorySettings().getClientSettings().getIdentificationTimeout().longValue() +
-                settings.getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+        this.timeout = settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
         this.maxNumberOfResultsPerConversation = SettingsUtils.getMaxClientPageSize();
         if (settings.getReferenceSettings().getIntegrityServiceSettings().isSetAbortOnFailedContributor()) {
             abortInCaseOfFailure = settings.getReferenceSettings().getIntegrityServiceSettings().isAbortOnFailedContributor();

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/UpdateFileIDsStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/UpdateFileIDsStep.java
@@ -38,6 +38,7 @@ import org.bitrepository.service.workflow.AbstractWorkFlowStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -52,7 +53,7 @@ public abstract class UpdateFileIDsStep extends AbstractWorkFlowStep {
     private final IntegrityInformationCollector collector;
     protected final IntegrityModel store;
     private final IntegrityAlerter alerter;
-    private final Long timeout;
+    private final Duration timeout;
     private final Integer maxNumberOfResultsPerConversation;
     protected final String collectionID;
     private boolean abortInCaseOfFailure = true;
@@ -71,8 +72,7 @@ public abstract class UpdateFileIDsStep extends AbstractWorkFlowStep {
         this.alerter = alerter;
         this.collectionID = collectionID;
         this.integrityContributors = integrityContributors;
-        this.timeout = settings.getRepositorySettings().getClientSettings().getIdentificationTimeout().longValue() +
-                settings.getRepositorySettings().getClientSettings().getOperationTimeout().longValue();
+        this.timeout = settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
         this.maxNumberOfResultsPerConversation = SettingsUtils.getMaxClientPageSize();
         if (settings.getReferenceSettings().getIntegrityServiceSettings().isSetAbortOnFailedContributor()) {
             abortInCaseOfFailure = settings.getReferenceSettings().getIntegrityServiceSettings().isAbortOnFailedContributor();

--- a/bitrepository-integrity-service/src/test/conf/RepositorySettings.xml
+++ b/bitrepository-integrity-service/src/test/conf/RepositorySettings.xml
@@ -50,8 +50,8 @@
   </ProtocolSettings>
 
   <ClientSettings>
-    <IdentificationTimeout>1000000</IdentificationTimeout>
-    <OperationTimeout>10000000</OperationTimeout>
+    <IdentificationTimeoutDuration>PT16M40S</IdentificationTimeoutDuration>
+    <OperationTimeoutDuration>PT2H46M40S</OperationTimeoutDuration>
   </ClientSettings>
 
   <GetAuditTrailSettings>

--- a/bitrepository-reference-pillar/src/test/resources/conf/RepositorySettings.xml
+++ b/bitrepository-reference-pillar/src/test/resources/conf/RepositorySettings.xml
@@ -56,8 +56,8 @@
   </ProtocolSettings>
 
   <ClientSettings>
-    <IdentificationTimeout>1000000</IdentificationTimeout>
-    <OperationTimeout>10000000</OperationTimeout>
+    <IdentificationTimeoutDuration>PT16M40S</IdentificationTimeoutDuration>
+    <OperationTimeoutDuration>PT2H46M40S</OperationTimeoutDuration>
   </ClientSettings>
 
   <GetAuditTrailSettings>

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
     <!-- Enable forbiddenapis plugin, do disable set to none -->
     <api.check.phase>process-classes</api.check.phase> <!-- forbidden-apis dislikes TestValidationUtils #validateUtilityClass -->
     <message.xml.version>31</message.xml.version>
-    <repository.settings.version>14-SNAPSHOT</repository.settings.version>
+    <repository.settings.version>14</repository.settings.version>
     <derby.version>10.14.2.0</derby.version>
     <activemq.version>5.16.4</activemq.version>
     <cxf.version>3.3.6</cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
     <!-- Enable forbiddenapis plugin, do disable set to none -->
     <api.check.phase>process-classes</api.check.phase> <!-- forbidden-apis dislikes TestValidationUtils #validateUtilityClass -->
     <message.xml.version>31</message.xml.version>
-    <repository.settings.version>13</repository.settings.version>
+    <repository.settings.version>14-SNAPSHOT</repository.settings.version>
     <derby.version>10.14.2.0</derby.version>
     <activemq.version>5.16.4</activemq.version>
     <cxf.version>3.3.6</cxf.version>


### PR DESCRIPTION
Following the changes to repository-settings the reference projects have been updated to use the new settings IdentificationTimeoutDuration and OperationTimeoutDuration and to prefer them over the old ones IdentificationTimeout and OperationTimeout. The old ones still work (for a transitional period) if the new ones are not set.

Please review. Please also help me consider how I should test the changes.

The reference settings have not been touched yet. They will be.

Link: https://sbforge.org/jira/browse/BITMAG-992