### PR TITLE
BITMAG-1134 : Put with Salt on existing file doesn't return salted checksum 

### DIFF
--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/PutFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/PutFileCmd.java
@@ -24,12 +24,10 @@ package org.bitrepository.commandline;
 import org.apache.commons.cli.Option;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForFileTYPE;
 import org.bitrepository.bitrepositoryelements.ChecksumSpecTYPE;
-import org.bitrepository.bitrepositoryelements.ChecksumType;
 import org.bitrepository.client.eventhandler.OperationEvent;
 import org.bitrepository.client.eventhandler.OperationEvent.OperationEventType;
 import org.bitrepository.commandline.eventhandler.CompleteEventAwaiter;
 import org.bitrepository.commandline.eventhandler.PutFileEventHandler;
-import org.bitrepository.common.utils.Base16Utils;
 import org.bitrepository.common.utils.ChecksumUtils;
 import org.bitrepository.modify.ModifyComponentFactory;
 import org.bitrepository.modify.putfile.PutFileClient;
@@ -178,15 +176,11 @@ public class PutFileCmd extends CommandLineClient {
 
         boolean printChecksums = cmdHandler.hasOption(REQUEST_CHECKSUM_TYPE_ARG);
         String saltedChecksum = null;
-        if (cmdHandler.hasOption(REQUEST_CHECKSUM_SALT_ARG)) {
-            String saltedAlg = cmdHandler.getOptionValue(REQUEST_CHECKSUM_TYPE_ARG);
-            String salt = cmdHandler.getOptionValue(REQUEST_CHECKSUM_SALT_ARG);
+        if (requestChecksum != null && requestChecksum.isSetChecksumSalt()) {
             try {
-                FileExchange fileexchange = ProtocolComponentFactory.getInstance().getFileExchange(settings);
-                ChecksumSpecTYPE checksumSpecType = new ChecksumSpecTYPE();
-                checksumSpecType.setChecksumType(ChecksumType.valueOf(saltedAlg));
-                checksumSpecType.setChecksumSalt(Base16Utils.encodeBase16(salt));
-                saltedChecksum = ChecksumUtils.generateChecksum(fileexchange.getFile(url), checksumSpecType);
+                FileExchange fileExchange = ProtocolComponentFactory.getInstance().getFileExchange(settings);
+                saltedChecksum = ChecksumUtils.generateChecksum(fileExchange.getFile(url), requestChecksum);
+                // TODO: Compare checksum of URL with the cmd-input checksum?
             } catch (IOException e) {
                 throw new IllegalArgumentException("Could not convert the given URL to URI.");
             }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/PutFileCmd.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/PutFileCmd.java
@@ -182,7 +182,7 @@ public class PutFileCmd extends CommandLineClient {
                 saltedChecksum = ChecksumUtils.generateChecksum(fileExchange.getFile(url), requestChecksum);
                 // TODO: Compare checksum of URL with the cmd-input checksum?
             } catch (IOException e) {
-                throw new IllegalArgumentException("Could not convert the given URL to URI.");
+                throw new IllegalArgumentException("Could not retrieve file from " + url);
             }
         }
 

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/PutFileEventHandler.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/PutFileEventHandler.java
@@ -32,8 +32,8 @@ import org.bitrepository.modify.putfile.conversation.PutFileCompletePillarEvent;
  * Prints out checksum results, if any.
  */
 public class PutFileEventHandler extends CompleteEventAwaiter {
-
     private final Boolean printOutput;
+    private final String saltedChecksum;
 
     /**
      * Constructor.
@@ -42,9 +42,10 @@ public class PutFileEventHandler extends CompleteEventAwaiter {
      * @param outputHandler The {@link OutputHandler} for handling output
      * @param printOutput   Setting for determining if output should be printed.
      */
-    public PutFileEventHandler(Settings settings, OutputHandler outputHandler, boolean printOutput) {
+    public PutFileEventHandler(Settings settings, OutputHandler outputHandler, boolean printOutput, String saltedChecksum) {
         super(settings, outputHandler);
         this.printOutput = printOutput;
+        this.saltedChecksum = saltedChecksum;
 
         if (printOutput) {
             output.resultHeader("PillarId \t Checksum");
@@ -54,15 +55,18 @@ public class PutFileEventHandler extends CompleteEventAwaiter {
     @Override
     public void handleComponentComplete(OperationEvent event) {
         if (!(event instanceof PutFileCompletePillarEvent)) {
-            output.warn("PutFileEventHandler received a component complete, which is not a "
-                    + PutFileCompletePillarEvent.class.getName());
+            output.warn("PutFileEventHandler received a component complete, which is not a " + PutFileCompletePillarEvent.class.getName());
         }
 
         assert event instanceof PutFileCompletePillarEvent;
         PutFileCompletePillarEvent pillarEvent = (PutFileCompletePillarEvent) event;
         if (printOutput && pillarEvent.getChecksums() != null) {
-            output.resultLine(
-                    pillarEvent.getContributorID() + " \t " + Base16Utils.decodeBase16(pillarEvent.getChecksums().getChecksumValue()));
+            if (saltedChecksum != null) {
+                output.resultLine(pillarEvent.getContributorID() + " \t " + saltedChecksum);
+            } else {
+                String checksum = Base16Utils.decodeBase16(pillarEvent.getChecksums().getChecksumValue());
+                output.resultLine(pillarEvent.getContributorID() + " \t " + checksum);
+            }
         }
     }
 

--- a/bitrepository-client/src/main/java/org/bitrepository/modify/putfile/BlockingPutFileClient.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/modify/putfile/BlockingPutFileClient.java
@@ -63,20 +63,13 @@ public class BlockingPutFileClient {
      * @return The list of {@link ContributorEvent}s received during the operation
      * @throws OperationFailedException The operation didn't complete successfully.
      */
-    public List<ContributorEvent> putFile(
-            String collectionID,
-            URL url,
-            String fileID,
-            long sizeOfFile,
-            ChecksumDataForFileTYPE checksumForValidationAtPillar,
-            ChecksumSpecTYPE checksumRequestsForValidation,
-            EventHandler eventHandler,
-            String auditTrailInformation)
-            throws OperationFailedException {
+    public List<ContributorEvent> putFile(String collectionID, URL url, String fileID, long sizeOfFile,
+                                          ChecksumDataForFileTYPE checksumForValidationAtPillar,
+                                          ChecksumSpecTYPE checksumRequestsForValidation, EventHandler eventHandler,
+                                          String auditTrailInformation) throws OperationFailedException {
         BlockingEventHandler blocker = new BlockingEventHandler(eventHandler);
-        client.putFile(collectionID, url, fileID, sizeOfFile, checksumForValidationAtPillar,
-                checksumRequestsForValidation,
-                blocker, auditTrailInformation);
+        client.putFile(collectionID, url, fileID, sizeOfFile, checksumForValidationAtPillar, checksumRequestsForValidation, blocker,
+                auditTrailInformation);
         OperationEvent finishEvent = blocker.awaitFinished();
         if (finishEvent.getEventType() == OperationEvent.OperationEventType.COMPLETE) {
             return blocker.getResults();

--- a/bitrepository-client/src/test/java/org/bitrepository/commandline/utils/ChecksumExtractionUtilsTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/commandline/utils/ChecksumExtractionUtilsTest.java
@@ -5,16 +5,16 @@
  * Copyright (C) 2010 - 2012 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
@@ -45,66 +45,63 @@ public class ChecksumExtractionUtilsTest extends DefaultFixtureClientTest {
         cmdHandler.addOption(new Option(Constants.REQUEST_CHECKSUM_TYPE_ARG, Constants.HAS_ARGUMENT, ""));
         output = mock(OutputHandler.class);
     }
-    
-    @Test(groups = { "regressiontest" })
+
+    @Test(groups = {"regressiontest"})
     public void testDefaultChecksumSpec() throws Exception {
         addDescription("Test that the default checksum is retrieved when no arguments are given.");
-        cmdHandler.parseArguments(new String[] {});
+        cmdHandler.parseArguments(new String[]{});
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertEquals(type.name(), settingsForCUT.getRepositorySettings().getProtocolSettings().getDefaultChecksumType());
     }
 
-    @Test(groups = { "regressiontest" })
+    @Test(groups = {"regressiontest"})
     public void testDefaultChecksumSpecWithSaltArgument() throws Exception {
         addDescription("Test that the HMAC version of default checksum is retrieved when the salt arguments are given.");
-        cmdHandler.parseArguments(new String[] {"-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110"});
+        cmdHandler.parseArguments(new String[]{"-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110"});
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertEquals(type.name(), "HMAC_" + settingsForCUT.getRepositorySettings().getProtocolSettings().getDefaultChecksumType());
     }
 
-    @Test(groups = { "regressiontest" })
+    @Test(groups = {"regressiontest"})
     public void testNonSaltChecksumSpecWithoutSaltArgument() throws Exception {
         addDescription("Test that a non-salt checksum type is retrieved when it is given as argument, and no salt arguments are given.");
         ChecksumType enteredType = ChecksumType.SHA384;
-        cmdHandler.parseArguments(new String[] {"-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType});
+        cmdHandler.parseArguments(new String[]{"-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType});
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertEquals(type, enteredType);
     }
 
-    @Test(groups = { "regressiontest" })
+    @Test(groups = {"regressiontest"})
     public void testNonSaltChecksumSpecWithSaltArgument() throws Exception {
         addDescription("Test that a salt checksum type is retrieved even though a non-salt checksum algorithm it is given as argument, "
                 + "but a salt argument also is given.");
         ChecksumType enteredType = ChecksumType.SHA512;
-        cmdHandler.parseArguments(new String[] {
-                "-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType,
-                "-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110"});
+        cmdHandler.parseArguments("-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType,
+                "-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110");
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertNotEquals(type, enteredType);
         assertEquals(type.name(), "HMAC_" + enteredType.name());
     }
 
-    @Test(groups = { "regressiontest" })
+    @Test(groups = {"regressiontest"})
     public void testSaltChecksumSpecWithoutSaltArgument() throws Exception {
         addDescription("Test that a non-salt checksum type is retrieved even though a salt checksum algorithm it is given as argument, "
                 + "but no salt argument also is given.");
         ChecksumType enteredType = ChecksumType.HMAC_SHA256;
-        cmdHandler.parseArguments(new String[] {
-                "-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType});
+        cmdHandler.parseArguments("-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType);
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertNotEquals(type, enteredType);
         assertTrue(enteredType.name().contains("HMAC"));
         assertEquals(type.name(), enteredType.name().replace("HMAC_", ""));
     }
 
-    @Test(groups = { "regressiontest" })
+    @Test(groups = {"regressiontest"})
     public void testSaltChecksumSpecWithSaltArgument() throws Exception {
         addDescription("Test that a salt checksum type is retrieved when the salt checksum algorithm it is given as argument, "
                 + "and a salt argument also is given.");
         ChecksumType enteredType = ChecksumType.HMAC_SHA256;
-        cmdHandler.parseArguments(new String[] {
-                "-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType,
-                "-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110"});
+        cmdHandler.parseArguments("-" + Constants.REQUEST_CHECKSUM_TYPE_ARG + enteredType,
+                "-" + Constants.REQUEST_CHECKSUM_SALT_ARG + "0110");
         ChecksumType type = ChecksumExtractionUtils.extractChecksumType(cmdHandler, settingsForCUT, output);
         assertEquals(type, enteredType);
     }

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
@@ -119,7 +119,7 @@ public final class ChecksumUtils {
      * @return The HMAC calculated checksum in hexadecimal.
      */
     public static String generateChecksum(InputStream content, ChecksumSpecTYPE csSpec) {
-        byte[] digest = null;
+        byte[] digest;
         ChecksumType algorithm = csSpec.getChecksumType();
 
         try {

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,13 +49,9 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class SaltedChecksumWorkflow extends Workflow {
     private final static Logger log = LoggerFactory.getLogger(SaltedChecksumWorkflow.class);
-    /**
-     * The context for the workflow.
-     */
     protected IntegrityWorkflowContext context;
     protected String collectionID;
     protected IntegrityContributors integrityContributors;
-    protected Date workflowStart;
     protected WorkflowStep step = null;
 
     /**
@@ -69,7 +64,7 @@ public class SaltedChecksumWorkflow extends Workflow {
     protected ChecksumSpecTYPE currentChecksumSpec = null;
 
     /**
-     * Remember to call the initialize method needs to be called before the start method.
+     * REMEMBER: the initialize method needs to be called before the start method.
      */
     public SaltedChecksumWorkflow() {}
 
@@ -85,7 +80,7 @@ public class SaltedChecksumWorkflow extends Workflow {
     @Override
     public void start() {
         if (context == null) {
-            throw new IllegalStateException("The workflow can not be started before the initialise method has been " + "called.");
+            throw new IllegalStateException("The workflow can not be started before the initialise method has been called.");
         }
         super.start();
 


### PR DESCRIPTION
**To reproduce, see:**
https://sbforge.org/jira/browse/BITMAG-1134

Now, when the PutFileCmd performs the PutFile operation; it will simply check if a salt arg (-S) has been supplied. If this is the case, it will compute the salted hash of the provided file by pulling it from FileExchange. There should never be an issues with this, since the instance where the information is returned happens after the pillar has verified that the checksum of the provided file matches the one already present on the pillar.