### PR TITLE
BEV-121 Fix download of large integrity report

### DIFF
--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/web/RestIntegrityService.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/web/RestIntegrityService.java
@@ -63,6 +63,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.file.Files;
@@ -372,7 +373,7 @@ public class RestIntegrityService {
     public Response getIntegrityReportsAsZIP(@QueryParam("collectionID") String collectionID,
                                              @QueryParam("reports") List<String> reports) {
         String fileName = "IntegrityReports.zip";
-        HashMap<String, File> files = new HashMap<>();
+        Map<String, File> files = new HashMap<>();
 
         for (String report : reports) {
             String[] parts = report.split("-", 2);
@@ -380,23 +381,27 @@ public class RestIntegrityService {
         }
 
         StreamingOutput streamingOutput = output -> {
-            ZipOutputStream zipOut = new ZipOutputStream(output);
             // Add the full integrity report to the hashmap
             files.put("report", integrityReportProvider.getLatestIntegrityReportReader(collectionID).getFullReport());
 
-            // Zip each file in the files hashmap
-            files.forEach((key, value) -> {
-                try {
-                    zipOut.putNextEntry(new ZipEntry(key));
-                    zipOut.write(Files.readAllBytes(value.toPath()));
-                    zipOut.flush();
-                } catch (IOException e) {
-                    throw new WebApplicationException(status(Status.INTERNAL_SERVER_ERROR).entity(
-                            "Something went wrong when trying to zip the file " + key + ".").type(
-                            MediaType.TEXT_PLAIN).build());
-                }
-            });
-            zipOut.close();
+            try (ZipOutputStream zipOut = new ZipOutputStream(output)) {
+                // Zip each file in the files hashmap
+                files.forEach((key, value) -> {
+                    try {
+                        zipOut.putNextEntry(new ZipEntry(key));
+                        try (InputStream is = Files.newInputStream(value.toPath())) {
+                            is.transferTo(zipOut);
+                        }
+                        zipOut.flush();
+                    } catch (IOException e) {
+                        throw new WebApplicationException(
+                                status(Status.INTERNAL_SERVER_ERROR)
+                                        .entity("Internal error when trying to zip the report file " + key + ": " + e)
+                                        .type(MediaType.TEXT_PLAIN)
+                                        .build());
+                    }
+                });
+            }
         };
         ResponseBuilder response = Response.ok();
         response.type("application/zip");

--- a/bitrepository-service/pom.xml
+++ b/bitrepository-service/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.4.1</version>
+      <version>42.4.5</version>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>


### PR DESCRIPTION
Trying to download a huge integrity report failed with an out-of-memory error and a status 500 in the web app. Fixed.