### PR TITLE
When logging time zone, use debug level and give human-readable zone ID

### DIFF
--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/CalendarUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/CalendarUtils.java
@@ -50,22 +50,25 @@ public final class CalendarUtils {
     }
 
     /**
-     * Get an instance of CalendarUtils with a non-server default timezone
+     * Get an instance of CalendarUtils with a non-server default timeZone
      *
-     * @param timezone The TimeZone to use
-     * @return The CelandarUtils instance for the non-standard timezone
+     * @param timeZone The TimeZone to use
+     * @return The CalendarUtils instance for the non-standard timeZone
      */
-    public static CalendarUtils getInstance(TimeZone timezone) {
+    public static CalendarUtils getInstance(TimeZone timeZone) {
         CalendarUtils cu = new CalendarUtils();
-        cu.setTimeZone(timezone);
+        cu.setTimeZone(timeZone);
         return cu;
     }
 
-    private void setTimeZone(TimeZone timezone) {
-        log.info("Using timezone: '{}'", timezone);
-        this.localTimeZone = timezone;
+    private void setTimeZone(TimeZone timeZone) {
+        log.debug("Using time zone: '{}'", getTimeZoneDisplayName(timeZone));
+        this.localTimeZone = timeZone;
     }
 
+    static String getTimeZoneDisplayName(TimeZone timeZone) {
+        return timeZone.getID();
+    }
 
     /**
      * Turns a date into a XMLGregorianCalendar.

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/CalendarUtilsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/CalendarUtilsTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -66,9 +67,17 @@ public class CalendarUtilsTest extends ExtendedTestCase {
         date = CalendarUtils.convertFromXMLGregorianCalendar(calendar);
         Assert.assertTrue(date.getTime() <= afterNow);
         Assert.assertTrue(date.getTime() >= beforeNow);
-        Assert.assertTrue(calendar.toGregorianCalendar().getTimeInMillis() == date.getTime());
+        Assert.assertEquals(date.getTime(), calendar.toGregorianCalendar().getTimeInMillis());
     }
-    
+
+    @Test
+    public void displaysNiceTimeZoneId() {
+        addDescription("Test that the time zone ID logged is human readable (for example Europe/Copenhagen)");
+        ZoneId zoneId = ZoneId.of("Europe/Copenhagen");
+        String displayName = CalendarUtils.getTimeZoneDisplayName(TimeZone.getTimeZone(zoneId));
+        Assert.assertEquals(displayName, "Europe/Copenhagen");
+    }
+
     @Test(groups = {"regressiontest"})
     public void startDateTest() throws ParseException {
         addDescription("Test that the start date is considered as localtime and converted into UTC.");
@@ -108,7 +117,7 @@ public class CalendarUtilsTest extends ExtendedTestCase {
         CalendarUtils cu = CalendarUtils.getInstance(TimeZone.getTimeZone("Europe/Copenhagen"));
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT);
         Date expectedStartOfDayInUTC = sdf.parse("2016-01-31T23:00:00.000Z");
-        System.out.println("expectedSTartofDayInUTC parsed: " + expectedStartOfDayInUTC.getTime());
+        System.out.println("expectedStartOfDayInUTC parsed: " + expectedStartOfDayInUTC.getTime());
         Date parsedStartOfDay = cu.makeStartDateObject("2016/02/01");
         Assert.assertEquals(parsedStartOfDay, expectedStartOfDayInUTC);
     }
@@ -129,7 +138,9 @@ public class CalendarUtilsTest extends ExtendedTestCase {
                 + "wintertime change is 25 hours (-1 millisecond).");
         CalendarUtils cu = CalendarUtils.getInstance(TimeZone.getTimeZone("Europe/Copenhagen"));
         Date startDate = cu.makeStartDateObject("2015/10/25");
+        Assert.assertNotNull(startDate);
         Date endDate = cu.makeEndDateObject("2015/10/25");
+        Assert.assertNotNull(endDate);
         long MS_PER_HOUR = 1000 * 60 * 60;
         long expectedIntervalLength = (MS_PER_HOUR * 25) - 1;
         Assert.assertEquals(endDate.getTime() - startDate.getTime(), expectedIntervalLength);
@@ -141,9 +152,12 @@ public class CalendarUtilsTest extends ExtendedTestCase {
                 + "summertime change is 23 hours (-1 millisecond).");
         CalendarUtils cu = CalendarUtils.getInstance(TimeZone.getTimeZone("Europe/Copenhagen"));
         Date startDate = cu.makeStartDateObject("2016/03/27");
+        Assert.assertNotNull(startDate);
         Date endDate = cu.makeEndDateObject("2016/03/27");
+        Assert.assertNotNull(endDate);
         long MS_PER_HOUR = 1000 * 60 * 60;
         long expectedIntervalLength = (MS_PER_HOUR * 23) - 1;
         Assert.assertEquals(endDate.getTime() - startDate.getTime(), expectedIntervalLength);
     }
+
 }


### PR DESCRIPTION
I got tired of the audit trail service log being filled up with messages like this one:

2025-07-31 13:02:36.436 INFO  o.b.common.utils.CalendarUtils - Using timezone: 'sun.util.calendar.ZoneInfo[id="Europe/Copenhagen",offset=3600000,dstSavings=3600000,useDaylight=true,transitions=143,lastRule=java.util.SimpleTimeZone[id=Europe/Copenhagen,offset=3600000,dstSavings=3600000,useDaylight=true,startYear=0,startMode=2,startMonth=2,startDay=-1,startDayOfWeek=1,startTime=3600000,startTimeMode=2,endMode=2,endMonth=9,endDay=-1,endDayOfWeek=1,endTime=3600000,endTimeMode=2]]'

Changed it so that logging happens at debug level and time zone is just given by its IANA time zone ID like 'Europe/Copenhagen'.