### PR TITLE
Initial migration from TestNG to JUnit 5

### DIFF
--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/BitrepositoryTestSuite.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/BitrepositoryTestSuite.java
@@ -1,0 +1,63 @@
+package org.bitrepository.protocol;
+
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.bitrepository.protocol.GlobalSuiteExtension;
+
+/**
+ * BitrepositoryTestSuite is a JUnit 5 suite class that groups and configures multiple test classes
+ * for the BitRepository project. This suite uses JUnit 5 annotations to select test classes, packages,
+ * and tags, and extend the suite with custom extensions.
+ *
+ * <p>JUnit 5 Annotations Used:</p>
+ * <ul>
+ *     <li>{@link Suite}: Indicates that this class is a JUnit 5 suite. It groups multiple test classes
+ *     into a single test suite.</li>
+ *     <li>{@link SelectClasses}: Specifies the test classes to be included in the suite. The value is an array
+ *     of class references to the test classes.</li>
+ *     <li>{@link SelectPackages}: Specifies the test packages to be included in the suite. The value is an array
+ *     of package names.</li>
+ *     <li>{@link IncludeTags}: Specifies the tags to include in the suite. The value is an array of tag names.</li>
+ *     <li>{@link ExcludeTags}: Specifies the tags to exclude from the suite. The value is an array of tag names.</li>
+ *     <li>{@link ExtendWith}: Specifies the extensions to be applied to the suite. The value is an array of
+ *     extension classes.</li>
+ * </ul>
+ *
+ * <p>Options in a JUnit 5 Suite:</p>
+ * <ul>
+ *     <li><strong>Selecting Test Classes:</strong> Use the {@link SelectClasses} annotation to specify the test
+ *     classes to be included in the suite. The value is an array of class references to the test classes.</li>
+ *     <li><strong>Selecting Test Packages:</strong> Use the {@link SelectPackages} annotation to specify the test
+ *     packages to be included in the suite. The value is an array of package names.</li>
+ *     <li><strong>Selecting Tests by Tag:</strong> Use the {@link IncludeTags} and {@link ExcludeTags} annotations
+ *     to specify the tags to include or exclude in the suite. The value is an array of tag names.</li>
+ *     <li><strong>Extending the Suite:</strong> Use the {@link ExtendWith} annotation to specify custom extensions
+ *     to be applied to the suite. The value is an array of extension classes.</li>
+ * </ul>
+ *
+ * <p>Example Usage:</p>
+ * <pre>
+ * {@code
+ * @Suite
+ * @SelectClasses({IntegrationTest.class})  // List your test classes here
+ * @SelectPackages("org.bitrepository.protocol")  // List your test packages here
+ * @IncludeTags("integration")  // List your include tags here
+ * @ExcludeTags("slow")  // List your exclude tags here
+ * @ExtendWith(GlobalSuiteExtension.class)
+ * public class BitrepositoryTestSuite {
+ *     // No need for methods here; this just groups and extends
+ * }
+ * }
+ * </pre>
+ */
+@Suite
+@SelectClasses({IntegrationTest.class})  // List your test classes here
+@ExtendWith(GlobalSuiteExtension.class)
+public class BitrepositoryTestSuite {
+    // No need for methods here; this just groups and extends
+}
+

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/GlobalSuiteExtension.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/GlobalSuiteExtension.java
@@ -61,7 +61,7 @@ public class GlobalSuiteExtension implements BeforeAllCallback, AfterAllCallback
                 DEFAULT_DOWNLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm();
                 DEFAULT_UPLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm() + "-" + DEFAULT_FILE_ID;
             } catch (MalformedURLException e) {
-                throw new RuntimeException("Never happens");
+                throw new RuntimeException("Never happens", e);
             }
         }
     }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/GlobalSuiteExtension.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/GlobalSuiteExtension.java
@@ -1,31 +1,5 @@
-/*
- * #%L
- * Bitrepository Common
- *
- * $Id$
- * $HeadURL$
- * %%
- * Copyright (C) 2010 - 2011 The State and University Library, The Royal Library and The State Archives, Denmark
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
- */
 package org.bitrepository.protocol;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.util.StatusPrinter;
 import org.bitrepository.common.settings.Settings;
 import org.bitrepository.common.settings.TestSettingsProvider;
 import org.bitrepository.common.utils.SettingsUtils;
@@ -40,24 +14,15 @@ import org.bitrepository.protocol.messagebus.SimpleMessageBus;
 import org.bitrepository.protocol.security.DummySecurityManager;
 import org.bitrepository.protocol.security.SecurityManager;
 import org.jaccept.TestEventManager;
-import org.jaccept.structure.ExtendedTestCase;
-import org.slf4j.LoggerFactory;
-import org.testng.ITestContext;
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.BeforeTest;
+import org.junit.jupiter.api.extension.*;
 
 import javax.jms.JMSException;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
 
-public abstract class IntegrationTest extends ExtendedTestCase {
+public class GlobalSuiteExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static boolean initialized = false;
     protected static TestEventManager testEventManager = TestEventManager.getInstance();
     public static LocalActiveMQBroker broker;
     public static EmbeddedHttpServer server;
@@ -76,30 +41,36 @@ public abstract class IntegrationTest extends ExtendedTestCase {
     protected static String DEFAULT_DOWNLOAD_FILE_ADDRESS;
     protected static String DEFAULT_UPLOAD_FILE_ADDRESS;
     protected String DEFAULT_AUDIT_INFORMATION;
-
     protected String testMethodName;
 
-    @BeforeSuite(alwaysRun = true)
-    public void initializeSuite(ITestContext testContext) {
-        //
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (!initialized) {
+            initialized = true;
+            settingsForCUT = loadSettings(getComponentID());
+            settingsForTestClient = loadSettings("TestSuiteInitialiser");
+            makeUserSpecificSettings(settingsForCUT);
+            makeUserSpecificSettings(settingsForTestClient);
+            httpServerConfiguration = new HttpServerConfiguration(settingsForTestClient.getReferenceSettings().getFileExchangeSettings());
+            collectionID = settingsForTestClient.getCollections().get(0).getID();
+
+            securityManager = createSecurityManager();
+            DEFAULT_FILE_ID = "DefaultFile";
+            try {
+                DEFAULT_FILE_URL = httpServerConfiguration.getURL(TestFileHelper.DEFAULT_FILE_ID);
+                DEFAULT_DOWNLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm();
+                DEFAULT_UPLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm() + "-" + DEFAULT_FILE_ID;
+            } catch (MalformedURLException e) {
+                throw new RuntimeException("Never happens");
+            }
+        }
     }
 
-    private void initializationMethod() {
-        settingsForCUT = loadSettings(getComponentID());
-        settingsForTestClient = loadSettings("TestSuiteInitialiser");
-        makeUserSpecificSettings(settingsForCUT);
-        makeUserSpecificSettings(settingsForTestClient);
-        httpServerConfiguration = new HttpServerConfiguration(settingsForTestClient.getReferenceSettings().getFileExchangeSettings());
-        collectionID = settingsForTestClient.getCollections().get(0).getID();
-
-        securityManager = createSecurityManager();
-        DEFAULT_FILE_ID = "DefaultFile";
-        try {
-            DEFAULT_FILE_URL = httpServerConfiguration.getURL(TestFileHelper.DEFAULT_FILE_ID);
-            DEFAULT_DOWNLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm();
-            DEFAULT_UPLOAD_FILE_ADDRESS = DEFAULT_FILE_URL.toExternalForm() + "-" + DEFAULT_FILE_ID;
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Never happens");
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (initialized) {
+            teardownMessageBus();
+            teardownHttpServer();
         }
     }
 
@@ -115,57 +86,7 @@ public abstract class IntegrationTest extends ExtendedTestCase {
     protected void addReceiver(MessageReceiver receiver) {
         receiverManager.addReceiver(receiver);
     }
-
-    @BeforeClass(alwaysRun = true)
-    public void initMessagebus() {
-        initializationMethod();
-        setupMessageBus();
-    }
-
-    @AfterSuite(alwaysRun = true)
-    public void shutdownSuite() {
-        teardownMessageBus();
-        teardownHttpServer();
-    }
-
-    /**
-     * Defines the standard BitRepositoryCollection configuration
-     */
-    @BeforeMethod(alwaysRun = true)
-    public final void beforeMethod(Method method) {
-        testMethodName = method.getName();
-        setupSettings();
-        NON_DEFAULT_FILE_ID = TestFileHelper.createUniquePrefix(testMethodName);
-        DEFAULT_AUDIT_INFORMATION = testMethodName;
-        receiverManager = new MessageReceiverManager(messageBus);
-        registerMessageReceivers();
-        messageBus.setCollectionFilter(List.of());
-        messageBus.setComponentFilter(List.of());
-        receiverManager.startListeners();
-        initializeCUT();
-    }
-
-
     protected void initializeCUT() {}
-
-    @AfterMethod(alwaysRun = true)
-    public final void afterMethod(ITestResult testResult) {
-        if (receiverManager != null) {
-            receiverManager.stopListeners();
-        }
-        if (testResult.isSuccess()) {
-            afterMethodVerification();
-        }
-        shutdownCUT();
-    }
-
-    /**
-     * May be used by specific tests for general verification when the test method has finished. Will only be run
-     * if the test has passed (so far).
-     */
-    protected void afterMethodVerification() {
-        receiverManager.checkNoMessagesRemainInReceivers();
-    }
 
     /**
      * Purges all messages from the receivers.
@@ -202,14 +123,6 @@ public abstract class IntegrationTest extends ExtendedTestCase {
         settings.getRepositorySettings().getProtocolSettings()
                 .setCollectionDestination(settings.getCollectionDestination() + getTopicPostfix());
         settings.getRepositorySettings().getProtocolSettings().setAlarmDestination(settings.getAlarmDestination() + getTopicPostfix());
-    }
-
-    @BeforeTest(alwaysRun = true)
-    public void writeLogStatus() {
-        if (System.getProperty("enableLogStatus", "false").equals("true")) {
-            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-            StatusPrinter.print(lc);
-        }
     }
 
     /**
@@ -291,4 +204,5 @@ public abstract class IntegrationTest extends ExtendedTestCase {
     protected SecurityManager createSecurityManager() {
         return new DummySecurityManager();
     }
+
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
@@ -27,7 +27,9 @@ import org.bitrepository.bitrepositorymessages.IdentifyPillarsForDeleteFileRespo
 import org.bitrepository.protocol.ProtocolComponentFactory;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;
 import org.bitrepository.protocol.message.ExampleMessageFactory;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -36,14 +38,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
-import static org.testng.Assert.assertEquals;
-
-/**
- * Runs the GeneralMessageBusTest using a LocalActiveMQBroker (if useEmbeddedMessageBus is true) and a suitable
- * MessageBus based on settingsForTestClient.  Regression tests utilized that uses JAccept to generate reports.
- */
-
-public class ActiveMQMessageBusTest extends GeneralMessageBusTest {
+public class ActiveMQMessageBusTest extends GeneralMessageBusTest {  // Assuming it extends a base class
 
     @Override
     protected void setupMessageBus() {
@@ -53,10 +48,10 @@ public class ActiveMQMessageBusTest extends GeneralMessageBusTest {
         }
         messageBus = new MessageBusWrapper(ProtocolComponentFactory.getInstance().getMessageBus(
                 settingsForTestClient, securityManager), testEventManager);
-
     }
 
-    @Test(groups = {"regressiontest"})
+    @Test
+    @Tag("regressiontest")
     public final void collectionFilterTest() throws Exception {
         addDescription("Test that message bus filters identify requests to other collection, eg. ignores these.");
         addStep("Send an identify request with a undefined 'Collection' header property, " +
@@ -90,7 +85,8 @@ public class ActiveMQMessageBusTest extends GeneralMessageBusTest {
         collectionReceiver.checkNoMessageIsReceived(IdentifyPillarsForDeleteFileRequest.class);
     }
 
-    @Test(groups = {"regressiontest"})
+    @Test
+    @Tag("regressiontest")
     public final void sendMessageToSpecificComponentTest() throws Exception {
         addDescription("Test that message bus correct uses the 'to' header property to indicated that the message " +
                 "is meant for a specific component");
@@ -113,10 +109,11 @@ public class ActiveMQMessageBusTest extends GeneralMessageBusTest {
         messageToSend.setTo(receiverID);
         messageBus.sendMessage(messageToSend);
         Message receivedMessage = messageList.poll(3, TimeUnit.SECONDS);
-        assertEquals(receivedMessage.getStringProperty(ActiveMQMessageBus.MESSAGE_TO_KEY), receiverID);
+        Assertions.assertEquals(receivedMessage.getStringProperty(ActiveMQMessageBus.MESSAGE_TO_KEY), receiverID);  // Assertion update
     }
 
-    @Test(groups = {"regressiontest"})
+    @Test
+    @Tag("regressiontest")
     public final void toFilterTest() throws Exception {
         addDescription("Test that message bus filters identify requests to other components, eg. ignores these.");
         addStep("Send an identify request with a undefined 'To' header property, " +

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfListenersStressTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfListenersStressTest.java
@@ -39,9 +39,13 @@ import org.bitrepository.protocol.security.DummySecurityManager;
 import org.bitrepository.protocol.security.SecurityManager;
 import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
 import org.jaccept.structure.ExtendedTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+//import org.testng.Assert;
+//import org.testng.annotations.BeforeMethod;
+//import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -110,7 +114,7 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
     private static boolean sendMoreMessages = true;
     private Settings settings;
 
-    @BeforeMethod
+    @BeforeEach
     public void initializeSettings() {
         settings = TestSettingsProvider.getSettings(getClass().getSimpleName());
     }
@@ -121,7 +125,8 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
      *
      * @throws Exception Can possibly throw an exception.
      */
-    @Test(groups = {"StressTest"})
+    @Test
+    @Tag("StressTest")
     public void testManyListenersOnLocalMessageBus() throws Exception {
         addDescription("Tests how many messages can be handled within a given timeframe when a given number of "
                 + "listeners are receiving them.");
@@ -155,7 +160,8 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
         }
     }
 
-    @Test(groups = {"StressTest"})
+    @Test
+    @Tag("StressTest")
     public void testManyListenersOnDistributedMessageBus() throws Exception {
         addDescription("Tests how many messages can be handled within a given timeframe when a given number of "
                 + "listeners are receiving them.");

--- a/pom.xml
+++ b/pom.xml
@@ -173,37 +173,18 @@
       <scope>runtime</scope>
     </dependency>
 
-      <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <version>2.3.6</version>
-          <scope>runtime</scope>
-      </dependency>
-
-<!--      <dependency>-->
-<!--          <groupId>org.mockito</groupId>-->
-<!--          <artifactId>mockito-core</artifactId>-->
-<!--          <version>3.3.3</version>-->
-<!--          <scope>test</scope>@AfterEach-->
-<!--      </dependency>-->
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-junit-jupiter</artifactId>
-          <version>5.12.0</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter</artifactId>
-          <version>5.10.3</version>
-          <scope>test</scope>
-      </dependency>
-      <!-- Hook up the other loggers to use SLF4J -->
-      <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jul-to-slf4j</artifactId>
-          <version>${slf4j.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.3</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.testng</groupId>
@@ -462,14 +443,14 @@
           <configLocation>sonarCheckstyle.xml</configLocation>
         </configuration>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>com.github.spotbugs</groupId>-->
-<!--        <artifactId>spotbugs-maven-plugin</artifactId>-->
-<!--        <version>4.0.0</version>-->
-<!--        <configuration>-->
-<!--          <failOnError>false</failOnError>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.0.0</version>
+        <configuration>
+          <failOnError>false</failOnError>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -478,7 +459,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.26.0</version>
+        <version>3.28.0</version>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -173,13 +173,50 @@
       <scope>runtime</scope>
     </dependency>
 
+      <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>2.3.6</version>
+          <scope>runtime</scope>
+      </dependency>
+
+<!--      <dependency>-->
+<!--          <groupId>org.mockito</groupId>-->
+<!--          <artifactId>mockito-core</artifactId>-->
+<!--          <version>3.3.3</version>-->
+<!--          <scope>test</scope>@AfterEach-->
+<!--      </dependency>-->
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-junit-jupiter</artifactId>
+          <version>5.12.0</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>5.10.3</version>
+          <scope>test</scope>
+      </dependency>
+      <!-- Hook up the other loggers to use SLF4J -->
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jul-to-slf4j</artifactId>
+          <version>${slf4j.version}</version>
+      </dependency>
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>7.1.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
+      <dependency>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-suite-engine</artifactId>
+          <version>1.10.3</version>  <!-- Match your JUnit version -->
+          <scope>test</scope>
+      </dependency>    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>3.3.3</version>
@@ -415,33 +452,33 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.4.5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.0</version>
         <configuration>
           <configLocation>sonarCheckstyle.xml</configLocation>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.0.0</version>
-        <configuration>
-          <failOnError>false</failOnError>
-        </configuration>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>com.github.spotbugs</groupId>-->
+<!--        <artifactId>spotbugs-maven-plugin</artifactId>-->
+<!--        <version>4.0.0</version>-->
+<!--        <configuration>-->
+<!--          <failOnError>false</failOnError>-->
+<!--        </configuration>-->
+<!--      </plugin>-->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.12</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.13.0</version>
+        <version>3.26.0</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
- Added JUnit 5 annotations to BitrepositoryTestSuite
- Added GlobalSuiteExtension to implement JUnit 5 extension points for suite-level setup and teardown.
- Ensured consistency and correctness of test suite configuration and setup methods.

This commit updates the test suite configuration to use JUnit 5 annotations, allowing for more flexible and powerful test suite management.

It doesn't handle the TestNG @dependsOnGroups, because it collides with one of the principles of JUnit, which is that the test should run without depending on other tests.