### PR TITLE
BITMAG-1246-better-logging

### DIFF
--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/ChecksumUtils.java
@@ -201,7 +201,6 @@ public final class ChecksumUtils {
 
             return messageAuthenticationCode.doFinal();
         } catch (Exception e) {
-            e.printStackTrace();
             throw new CoordinationLayerException(
                     "Cannot calculate the checksum with algorithm '" + algorithmName + "' and salt '" + Arrays.toString(salt) + "'", e);
         }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/IntegrationTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/IntegrationTest.java
@@ -41,6 +41,7 @@ import org.bitrepository.protocol.messagebus.MessageBusManager;
 import org.bitrepository.protocol.messagebus.SimpleMessageBus;
 import org.bitrepository.protocol.security.DummySecurityManager;
 import org.bitrepository.protocol.security.SecurityManager;
+import org.bitrepository.protocol.utils.TestWatcherExtension;
 import org.jaccept.TestEventManager;
 import org.jaccept.structure.ExtendedTestCase;
 import org.junit.jupiter.api.*;
@@ -51,11 +52,7 @@ import org.slf4j.LoggerFactory;
 import javax.jms.JMSException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.bitrepository.protocol.utils.TestWatcherExtension;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.TestWatcher;
+import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(ExtendedTestInfoParameterResolver.class)

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfListenersStressTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfListenersStressTest.java
@@ -49,7 +49,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -67,10 +66,6 @@ import java.util.List;
  * 'OUTPUT_FILE_NAME' which is the name of the file to write the output results.
  */
 public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
-    /**
-     * The queue name.
-     */
-    private static String QUEUE = "TEST-LISTENERS";
     /**
      * The default time to wait for a simple communication.
      */
@@ -112,10 +107,12 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
      */
     private static boolean sendMoreMessages = true;
     private Settings settings;
+    private String testQueue;
 
     @BeforeEach
     public void initializeSettings() {
         settings = TestSettingsProvider.getSettings(getClass().getSimpleName());
+        testQueue = "TEST-LISTENERS-" + System.currentTimeMillis();
     }
 
     /**
@@ -130,7 +127,6 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
         addDescription("Tests how many messages can be handled within a given timeframe when a given number of "
                 + "listeners are receiving them.");
         addStep("Define constants", "This should not be possible to fail.");
-        QUEUE += "-" + (new Date()).getTime();
         messageReceived = 0;
         idReached = -1;
         sendMoreMessages = true;
@@ -138,7 +134,7 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
         addStep("Define the message to send.",
                 "Should retrieve the Alarm message from examples and set the To.");
         alarmMessage = ExampleMessageFactory.createMessage(AlarmMessage.class);
-        alarmMessage.setDestination(QUEUE);
+        alarmMessage.setDestination(testQueue);
 
         addStep("Make configuration for the messagebus.", "Both should be created.");
         settings.getRepositorySettings().getProtocolSettings().setMessageBusConfiguration(
@@ -173,7 +169,6 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
         addDescription("Tests how many messages can be handled within a given timeframe when a given number of "
                 + "listeners are receiving them.");
         addStep("Define constants", "This should not be possible to fail.");
-        QUEUE += "-" + (new Date()).getTime();
         messageReceived = 0;
         idReached = -1;
         sendMoreMessages = true;
@@ -181,7 +176,7 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
         addStep("Define the message to send.",
                 "Should retrieve the Alarm message from examples and set the To.");
         alarmMessage = ExampleMessageFactory.createMessage(AlarmMessage.class);
-        alarmMessage.setDestination(QUEUE);
+        alarmMessage.setDestination(testQueue);
 
         addStep("Make configuration for the messagebus.", "Both should be created.");
         MessageBusConfiguration conf = new MessageBusConfiguration();
@@ -218,18 +213,16 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
             addStep("Initialise the message listeners.",
                     "Should be created and connected to the message bus.");
             for (int i = 0; i < NUMBER_OF_LISTENERS; i++) {
-                Settings listenerSettings = TestSettingsProvider.getSettings(getClass().getSimpleName());
+                Settings listenerSettings = TestSettingsProvider.getSettings(getClass().getSimpleName() + i);
                 listenerSettings.getRepositorySettings().getProtocolSettings().setMessageBusConfiguration(conf);
-                listeners.add(new NotificationMessageListener(listenerSettings, securityManager));
+                listeners.add(new NotificationMessageListener(listenerSettings, securityManager, testQueue));
             }
 
             addStep("Wait for setup", "We wait!");
-            synchronized (this) {
-                try {
-                    wait(DEFAULT_WAIT_TIME);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME);
+            } catch (InterruptedException e) {
+                Assertions.fail(e);
             }
 
 
@@ -238,23 +231,19 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
 
             addStep("Wait for the timeframe on '" + TIME_FRAME + "' milliseconds.",
                     "We wait!");
-            synchronized (this) {
-                try {
-                    wait(TIME_FRAME);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+            try {
+                Thread.sleep(TIME_FRAME);
+            } catch (InterruptedException e) {
+                Assertions.fail(e);
             }
 
             addStep("Stop sending more messages and await all the messages to be received by all the listeners",
                     "Should be Ok");
             sendMoreMessages = false;
-            synchronized (this) {
-                try {
-                    wait(DEFAULT_WAIT_TIME);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME);
+            } catch (InterruptedException e) {
+                Assertions.fail(e);
             }
 
             addStep("Verifying the amount of message sent '" + idReached + "' has been received by all '"
@@ -286,12 +275,10 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
             }
             listeners.clear();
 
-            synchronized (this) {
-                try {
-                    wait(DEFAULT_WAIT_TIME);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+            try {
+                Thread.sleep(DEFAULT_WAIT_TIME);
+            } catch (InterruptedException e) {
+                Assertions.fail(e);
             }
         }
     }
@@ -349,24 +336,26 @@ public class MessageBusNumberOfListenersStressTest extends ExtendedTestCase {
          * The amount of messages received.
          */
         private int count;
+        private final String queueName;
 
         /**
          * Constructor.
          *
          * @param settings The configuration for defining the message bus.
          */
-        public NotificationMessageListener(Settings settings, SecurityManager securityManager) {
+        public NotificationMessageListener(Settings settings, SecurityManager securityManager, String queueName) {
             this.bus = new ActiveMQMessageBus(settings, securityManager);
             this.count = 0;
+            this.queueName = queueName;
 
-            bus.addListener(QUEUE, this);
+            bus.addListener(queueName, this);
         }
 
         /**
          * Method for stopping interaction with the message listener.
          */
         public void stop() {
-            bus.removeListener(QUEUE, this);
+            bus.removeListener(queueName, this);
             try {
                 bus.close();
             } catch (javax.jms.JMSException e) {

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfMessagesStressTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusNumberOfMessagesStressTest.java
@@ -39,7 +39,11 @@ import org.bitrepository.protocol.security.DummySecurityManager;
 import org.bitrepository.protocol.security.SecurityManager;
 import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
 import org.jaccept.structure.ExtendedTestCase;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import javax.jms.JMSException;
 import java.io.IOException;
@@ -93,7 +97,7 @@ public class MessageBusNumberOfMessagesStressTest extends ExtendedTestCase {
                 try {
                     wait(timeFrame);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Assertions.fail(e);
                 }
             }
 
@@ -150,7 +154,7 @@ public class MessageBusNumberOfMessagesStressTest extends ExtendedTestCase {
                 try {
                     wait(timeFrame);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Assertions.fail(e);
                 }
             }
 

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusSizeOfMessageStressTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusSizeOfMessageStressTest.java
@@ -94,7 +94,7 @@ public class MessageBusSizeOfMessageStressTest extends ExtendedTestCase {
                 try {
                     wait(TIME_FRAME);
                 } catch (InterruptedException e) {
-                    /* e.printStackTrace(); */
+                    Assertions.fail(e);
                 }
             }
 
@@ -146,7 +146,7 @@ public class MessageBusSizeOfMessageStressTest extends ExtendedTestCase {
                 try {
                     wait(TIME_FRAME);
                 } catch (InterruptedException e) {
-                    /* e.printStackTrace(); */
+                    Assertions.fail(e);
                 }
             }
 

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusTimeToSendMessagesStressTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/performancetest/MessageBusTimeToSendMessagesStressTest.java
@@ -58,22 +58,16 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
      */
     static final int TIME_FOR_MESSAGE_TRANSFER_WAIT = 500;
     /**
-     * The name of the queue to send the messages.
-     */
-    private static String QUEUE = "TEST-QUEUE";
-    /**
      * The number of messages to send.
      */
     private static final int NUMBER_OF_MESSAGES = 1000;
-    /**
-     * The date for start sending the messages.
-     */
-    private static Date startSending;
     private Settings settings;
+    private String testQueue;
 
     @BeforeEach
     public void initializeSettings() {
         settings = TestSettingsProvider.getSettings(getClass().getSimpleName());
+        testQueue = "TEST-QUEUE-" + System.currentTimeMillis();
     }
 
     /**
@@ -84,13 +78,12 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
     @Tag("StressTest"} ) */
     public void SendManyMessagesDistributed() {
         addDescription("Tests how fast a given number of messages can be handled.");
-        addStep("Define constants", "This should not be possible to fail.");
-        QUEUE += "-" + (new Date()).getTime();
 
         addStep("Make configuration for the messagebus.", "Both should be created.");
         MessageBusConfiguration conf = MessageBusConfigurationFactory.createDefaultConfiguration();
         SecurityManager securityManager = new DummySecurityManager();
         CountMessagesListener listener = null;
+        Date startSending;
 
         try {
             addStep("Initialise the message-listener", "Should be allowed.");
@@ -103,12 +96,10 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
             addStep("Sleep until the listeners have received all the messages.",
                     "Should be sleeping.");
             while (!listener.isFinished()) {
-                synchronized (this) {
-                    try {
-                        wait(TIME_FOR_MESSAGE_TRANSFER_WAIT);
-                    } catch (InterruptedException e) {
-                        /* e.printStackTrace(); */
-                    }
+                try {
+                    Thread.sleep(TIME_FOR_MESSAGE_TRANSFER_WAIT);
+                } catch (InterruptedException e) {
+                    Assertions.fail(e);
                 }
             }
 
@@ -134,8 +125,6 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
     @Tag("StressTest")
     public void SendManyMessagesLocally() throws Exception {
         addDescription("Tests how many messages can be handled within a given timeframe.");
-        addStep("Define constants", "This should not be possible to fail.");
-        QUEUE += "-" + (new Date()).getTime();
 
         addStep("Make configuration for the messagebus and define the local broker.",
                 "Both should be created.");
@@ -156,20 +145,18 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
             addStep("Initialise the message-listener", "Should be allowed.");
             listener = new CountMessagesListener(securityManager);
 
-            startSending = new Date();
+            Date startSending = new Date();
             addStep("Start sending at '" + startSending + "'", "Should just be waiting.");
             sendAllTheMessages(conf, securityManager);
 
             addStep("Sleep until the listeners has received all the messages.", "Should be sleeping.");
-            long startTime = new Date().getTime();
+            long startTime = System.currentTimeMillis();
             long oneMinuteInMillis = 60000;
-            while (!listener.isFinished() && (new Date().getTime() - startTime) < oneMinuteInMillis) {
-                synchronized (this) {
-                    try {
-                        wait(TIME_FOR_MESSAGE_TRANSFER_WAIT);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
+            while (!listener.isFinished() && (System.currentTimeMillis() - startTime) < oneMinuteInMillis) {
+                try {
+                    Thread.sleep(TIME_FOR_MESSAGE_TRANSFER_WAIT);
+                } catch (InterruptedException e) {
+                    Assertions.fail(e);
                 }
             }
 
@@ -218,7 +205,8 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
         private final String id;
 
         public MessageSenderThread(MessageBusConfiguration conf, SecurityManager securityManager, int numberOfMessages, String id) {
-            Settings senderSettings = TestSettingsProvider.getSettings(MessageBusTimeToSendMessagesStressTest.class.getSimpleName());
+            Settings senderSettings = TestSettingsProvider.getSettings(
+                    MessageBusTimeToSendMessagesStressTest.class.getSimpleName() + id);
             senderSettings.getRepositorySettings().getProtocolSettings().setMessageBusConfiguration(conf);
             this.bus = new ActiveMQMessageBus(senderSettings, securityManager);
             this.numberOfMessages = numberOfMessages;
@@ -229,7 +217,7 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
         public void run() {
             try {
                 AlarmMessage message = ExampleMessageFactory.createMessage(AlarmMessage.class);
-                message.setDestination(QUEUE);
+                message.setDestination(testQueue);
                 for (int i = 0; i < numberOfMessages; i++) {
                     message.setCorrelationID(id + ":" + i);
                     bus.sendMessage(message);
@@ -264,14 +252,14 @@ public class MessageBusTimeToSendMessagesStressTest extends ExtendedTestCase {
             this.bus = new ActiveMQMessageBus(settings, securityManager);
             this.count = 0;
 
-            bus.addListener(QUEUE, this);
+            bus.addListener(testQueue, this);
         }
 
         /**
          * Method for stopping interaction with the message-listener.
          */
         public void stop() {
-            bus.removeListener(QUEUE, this);
+            bus.removeListener(testQueue, this);
             try {
                 bus.close();
             } catch (javax.jms.JMSException e) {

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/PillarRunner.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/PillarRunner.java
@@ -21,10 +21,14 @@
  */
 package org.bitrepository.pillar;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Launches a given pillar.
  */
 public final class PillarRunner {
+    private static final Logger log = LoggerFactory.getLogger(PillarRunner.class);
 
     private PillarRunner() {}
 
@@ -39,7 +43,7 @@ public final class PillarRunner {
                 pillar.wait();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.warn("PillarRunner caught exception: ", e);
             System.exit(0);
         }
     }

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/PillarIntegrationTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/PillarIntegrationTest.java
@@ -46,6 +46,8 @@ import org.jaccept.TestEventManager;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.suite.api.AfterSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jms.JMSException;
 import java.io.IOException;
@@ -60,6 +62,7 @@ import java.io.InputStream;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(ExtendedTestInfoParameterResolver.class)
 public abstract class PillarIntegrationTest extends IntegrationTest {
+    private static final Logger log = LoggerFactory.getLogger(PillarIntegrationTest.class);
     /**
      * The path to the directory containing the integration test configuration files
      */
@@ -140,7 +143,7 @@ public abstract class PillarIntegrationTest extends IntegrationTest {
                 try {
                     messageBus.close();
                 } catch (JMSException e) {
-                    e.printStackTrace();
+                    log.warn("Failed to close message bus", e);
                 }
                 messageBus = null;
             }
@@ -293,8 +296,7 @@ public abstract class PillarIntegrationTest extends IntegrationTest {
             try (InputStream fis = getClass().getClassLoader().getResourceAsStream("default-test-file.txt")) {
                 fe.putFile(fis, defaultFileUrl);
             } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                Assertions.fail(e);
             }
 
 

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/perf/PillarPerformanceTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/integration/perf/PillarPerformanceTest.java
@@ -37,6 +37,7 @@ import org.bitrepository.protocol.bus.MessageReceiver;
 import org.bitrepository.protocol.messagebus.MessageListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -75,7 +76,7 @@ public class PillarPerformanceTest extends PillarIntegrationTest {
             try {
                 Thread.sleep(6000);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                Assertions.fail(e);
             }
             System.out.println("...waiting for the last " + (numberOfOperations - metrics.getCount()) +
                     " operations to finish " +

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/messagehandling/ReplaceFileTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/messagehandling/ReplaceFileTest.java
@@ -339,7 +339,7 @@ public class ReplaceFileTest extends MockedPillarTest {
             try {
                 res.setChecksumValue(Base16Utils.encodeBase16(NON_DEFAULT_MD5_CHECKSUM));
             } catch (DecoderException e) {
-                e.printStackTrace();
+                Assertions.fail(e);
             }
             return res;
         }).when(model).getChecksumDataForFile(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.eq(otherCsSpec));


### PR DESCRIPTION
Replaced e.printStacktrace with Assertions in teset code and either removed or logged in the other code. 
Made 3 test methods which had e.printStatcktrace to succeed to be sure that the cause of the failure was not an error that should have been registered by the exception code.