### PR TITLE
Days should also be allowed in CollectionAuditInterval

### DIFF
--- a/bitrepository-audit-trail-service/src/test/java/org/bitrepository/audittrails/AuditTrailServiceTest.java
+++ b/bitrepository-audit-trail-service/src/test/java/org/bitrepository/audittrails/AuditTrailServiceTest.java
@@ -36,8 +36,10 @@ import org.bitrepository.common.DefaultThreadFactory;
 import org.bitrepository.common.settings.Settings;
 import org.bitrepository.common.settings.TestSettingsProvider;
 import org.bitrepository.common.utils.AllureTestUtils;
+import org.bitrepository.common.utils.SettingsUtils;
 import org.bitrepository.service.AlarmDispatcher;
 import org.bitrepository.service.contributor.ContributorMediator;
+import org.bitrepository.settings.referencesettings.ClientSettings;
 import org.bitrepository.settings.repositorysettings.Collection;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -75,6 +77,9 @@ public class AuditTrailServiceTest {
         c.setID(TEST_COLLECTION);
         settings.getRepositorySettings().getCollections().getCollection().add(c);
         threadFactory = new DefaultThreadFactory(this.getClass().getSimpleName(), Thread.NORM_PRIORITY);
+        ClientSettings clientSettings = settings.getReferenceSettings().getClientSettings();
+        clientSettings.setMaxPageSize(BigInteger.valueOf(1000));
+        SettingsUtils.initialize(settings);
     }
 
     @Test

--- a/bitrepository-core/src/test/java/org/bitrepository/settings/SettingsProviderTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/settings/SettingsProviderTest.java
@@ -28,14 +28,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.ThreadFactory;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.Duration;
 
 class SettingsProviderTest {
     private static final String PATH_TO_TEST_SETTINGS = "settings/xml/bitrepository-devel";
-
-    public static final String TEST_COLLECTION = "dummy-collection";
-    public static final String DEFAULT_CONTRIBUTOR = "Contributor1";
-    private ThreadFactory threadFactory;
 
     @Test
     @Tag("regressiontest")
@@ -71,28 +69,17 @@ class SettingsProviderTest {
 
     @Test
     @Tag("regressiontest")
-    void collectAuditIntervalTest() {
+    void collectAuditIntervalTest() throws DatatypeConfigurationException {
         SettingsProvider settingsLoader =
                 new SettingsProvider(new XMLFileSettingsLoader(PATH_TO_TEST_SETTINGS), "TestComponentID");
 
         Settings settings = settingsLoader.getSettings();
 
-        Assertions.assertEquals(1, settings.getReferenceSettings()
-                .getAuditTrailServiceSettings()
-                .getCollectAuditInterval()
-                .getDays());
-        Assertions.assertEquals(1, settings.getReferenceSettings()
-                .getAuditTrailServiceSettings()
-                .getCollectAuditInterval()
-                .getHours());
-        Assertions.assertEquals(22, settings.getReferenceSettings()
-                .getAuditTrailServiceSettings()
-                .getCollectAuditInterval()
-                .getMinutes());
-        Assertions.assertEquals(22, settings.getReferenceSettings()
-                .getAuditTrailServiceSettings()
-                .getCollectAuditInterval()
-                .getSeconds());
+        DatatypeFactory factory = DatatypeFactory.newInstance();
+        Duration expectedInterval =
+                factory.newDuration(true, 0, 0, 1, 1, 22, 22);
+        Assertions.assertEquals(expectedInterval,
+                settings.getReferenceSettings().getAuditTrailServiceSettings().getCollectAuditInterval());
     }
 
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/settings/SettingsProviderTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/settings/SettingsProviderTest.java
@@ -28,8 +28,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ThreadFactory;
+
 class SettingsProviderTest {
     private static final String PATH_TO_TEST_SETTINGS = "settings/xml/bitrepository-devel";
+
+    public static final String TEST_COLLECTION = "dummy-collection";
+    public static final String DEFAULT_CONTRIBUTOR = "Contributor1";
+    private ThreadFactory threadFactory;
 
     @Test
     @Tag("regressiontest")
@@ -62,4 +68,31 @@ class SettingsProviderTest {
         Assertions.assertEquals(originalCollectionID, settings.getRepositorySettings().getCollections().getCollection().get(0).getID());
         Assertions.assertEquals(originalCollectionID, settings.getCollections().get(0).getID());
     }
+
+    @Test
+    @Tag("regressiontest")
+    void collectAuditIntervalTest() {
+        SettingsProvider settingsLoader =
+                new SettingsProvider(new XMLFileSettingsLoader(PATH_TO_TEST_SETTINGS), "TestComponentID");
+
+        Settings settings = settingsLoader.getSettings();
+
+        Assertions.assertEquals(1, settings.getReferenceSettings()
+                .getAuditTrailServiceSettings()
+                .getCollectAuditInterval()
+                .getDays());
+        Assertions.assertEquals(1, settings.getReferenceSettings()
+                .getAuditTrailServiceSettings()
+                .getCollectAuditInterval()
+                .getHours());
+        Assertions.assertEquals(22, settings.getReferenceSettings()
+                .getAuditTrailServiceSettings()
+                .getCollectAuditInterval()
+                .getMinutes());
+        Assertions.assertEquals(22, settings.getReferenceSettings()
+                .getAuditTrailServiceSettings()
+                .getCollectAuditInterval()
+                .getSeconds());
+    }
+
 }

--- a/bitrepository-core/src/test/resources/settings/xml/bitrepository-devel/ReferenceSettings.xml
+++ b/bitrepository-core/src/test/resources/settings/xml/bitrepository-devel/ReferenceSettings.xml
@@ -72,7 +72,7 @@
       <DriverClass>org.apache.derby.jdbc.EmbeddedDriver</DriverClass>
       <DatabaseURL>jdbc:derby:target/auditservicedb</DatabaseURL>
     </AuditTrailServiceDatabase>
-    <CollectAuditInterval>PT1H</CollectAuditInterval>
+    <CollectAuditInterval>P1DT1H22M22S</CollectAuditInterval>
     <TimerTaskCheckInterval>60000</TimerTaskCheckInterval>
     <AuditTrailPreservation>
       <AuditTrailPreservationInterval>P7D</AuditTrailPreservationInterval>

--- a/bitrepository-reference-settings/src/main/resources/xsd/ReferenceSettings.xsd
+++ b/bitrepository-reference-settings/src/main/resources/xsd/ReferenceSettings.xsd
@@ -728,13 +728,14 @@
           <xs:annotation>
             <xs:documentation xml:lang="en">
               The interval between each collecting of audit trail data from the contributors.
-              Non-negative XML schema durations consisting of hours, minutes and/or seconds are accepted.
-              The hours may be more than 24. The seconds may have up to 9 decimals of fraction.
+              Non-negative XML schema durations consisting of days, hours, minutes and/or seconds are accepted.
+              The seconds may have up to 9 decimals of fraction.
+              For example P1D (1 day), PT3M (3 minutes), P1DT1H22M22.5S (1 day 1 hour 22 minutes 22.5 seconds).
             </xs:documentation>
           </xs:annotation>
           <xs:simpleType>
             <xs:restriction base="xs:duration">
-              <xs:pattern value="PT(\d+H)?(\d+M)?(\d+(\.\d{1,9})?S)?" />
+              <xs:pattern value="P(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d{1,9})?S)?)?" />
             </xs:restriction>
           </xs:simpleType>
         </xs:element>

--- a/bitrepository-reference-settings/src/main/resources/xsd/ReferenceSettings.xsd
+++ b/bitrepository-reference-settings/src/main/resources/xsd/ReferenceSettings.xsd
@@ -730,6 +730,7 @@
               The interval between each collecting of audit trail data from the contributors.
               Non-negative XML schema durations consisting of days, hours, minutes and/or seconds are accepted.
               The seconds may have up to 9 decimals of fraction.
+              A day will be understood as 24 hours always.
               For example P1D (1 day), PT3M (3 minutes), P1DT1H22M22.5S (1 day 1 hour 22 minutes 22.5 seconds).
             </xs:documentation>
           </xs:annotation>


### PR DESCRIPTION
Changed the value in ReferenceSettings.xsd from PT(\d+H)?(\d+M)?(\d+(\.\d{1,9})?S)? to P(\d+D)?(T(\d+H)?(\d+M)?(\d+(\.\d{1,9})?S)?)? 
Tested the change in collectAuditIntervalTest in test class SettingsProviderTest