### PR TITLE
 Convert immutable classes to Java records

### DIFF
--- a/bitrepository-client/src/main/java/org/bitrepository/access/getfile/conversation/GettingFile.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/access/getfile/conversation/GettingFile.java
@@ -52,11 +52,11 @@ class GettingFile extends PerformingOperationState {
      * @param pillar  The pillar the file should be requested from.
      */
     public GettingFile(GetFileConversationContext context, SelectedComponentInfo pillar) {
-        super(pillar.getID());
+        super(pillar.componentID());
         this.context = context;
         this.selectedPillar = pillar;
         contributors = new HashSet<>();
-        contributors.add(pillar.getID());
+        contributors.add(pillar.componentID());
     }
 
     @Override
@@ -66,8 +66,8 @@ class GettingFile extends PerformingOperationState {
         msg.setFileAddress(context.getUrlForResult().toExternalForm());
         msg.setFileID(context.getFileID());
         msg.setFilePart(context.getFilePart());
-        msg.setPillarID(selectedPillar.getID());
-        msg.setDestination(selectedPillar.getDestination());
+        msg.setPillarID(selectedPillar.componentID());
+        msg.setDestination(selectedPillar.componentTopic());
         context.getMonitor().requestSent("Sending GetFileRequest to ", selectedPillar.toString());
         context.getMessageSender().sendMessage(msg);
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/GeneralConversationState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/GeneralConversationState.java
@@ -75,7 +75,7 @@ public abstract class GeneralConversationState implements ConversationState {
             if (!responseStatus.getOutstandingComponents().isEmpty()) {
                 if (getTimeoutValue().compareTo(Duration.ZERO) > 0) { // TODO From Java 18 use: getTimeoutValue().isPositive()
                     CountAndTimeUnit delay = TimeUtils.durationToCountAndTimeUnit(getTimeoutValue());
-                    scheduledTimeout = timer.schedule(new TimeoutHandler(), delay.getCount(), delay.getUnit());
+                    scheduledTimeout = timer.schedule(new TimeoutHandler(), delay.count(), delay.unit());
                 }
                 sendRequest();
             } else {

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/IdentifyingState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/IdentifyingState.java
@@ -122,7 +122,7 @@ public abstract class IdentifyingState extends GeneralConversationState {
     private void generateContributorsSelectedEvent(Collection<SelectedComponentInfo> selectedComponentInfo) {
         List<String> selectedComponentIDs = new LinkedList<>();
         for (SelectedComponentInfo componentInfo : selectedComponentInfo) {
-            selectedComponentIDs.add(componentInfo.getID());
+            selectedComponentIDs.add(componentInfo.componentID());
         }
         getContext().getMonitor().contributorsSelected(selectedComponentIDs);
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/PerformingOperationState.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/PerformingOperationState.java
@@ -50,7 +50,7 @@ public abstract class PerformingOperationState extends GeneralConversationState 
         super(toComponentIDs(expectedContributors));
         this.activeContributors = new HashMap<>();
         for (SelectedComponentInfo contributorInfo : expectedContributors) {
-            activeContributors.put(contributorInfo.getID(), contributorInfo.getDestination());
+            activeContributors.put(contributorInfo.componentID(), contributorInfo.componentTopic());
         }
     }
 
@@ -114,7 +114,7 @@ public abstract class PerformingOperationState extends GeneralConversationState 
     private static Collection<String> toComponentIDs(Collection<SelectedComponentInfo> contributors) {
         Collection<String> componentIDs = new HashSet<>();
         for (SelectedComponentInfo componentInfo : contributors) {
-            componentIDs.add(componentInfo.getID());
+            componentIDs.add(componentInfo.componentID());
         }
         return componentIDs;
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
@@ -28,22 +28,27 @@ import org.jspecify.annotations.NonNull;
 
 /**
  * Container for information about a pillar which has been identified and marked as selected for a request.
+ *
+ * @param componentID    The ID of the selected pillar
+ * @param componentTopic The topic for communication with the selected pillar
  */
-public record SelectedComponentInfo(String componentID, String componentTopic) {
+public record SelectedComponentInfo(@NonNull String componentID, @NonNull String componentTopic) {
 
     /**
+     * @return The ID of the pillar chosen by this selector
      * @deprecated Use {@link #componentID()} instead
      */
     @Deprecated(forRemoval = true)
-    public String getID() {
+    public @NonNull String getID() {
         return componentID;
     }
 
     /**
+     * @return The topic for sending messages to the pillar chosen by this selector
      * @deprecated Use {@link #componentTopic()} instead
      */
     @Deprecated(forRemoval = true)
-    public String getDestination() {
+    public @NonNull String getDestination() {
         return componentTopic;
     }
 

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
@@ -31,10 +31,18 @@ import org.jspecify.annotations.NonNull;
  */
 public record SelectedComponentInfo(String componentID, String componentTopic) {
 
+    /**
+     * @deprecated Use {@link #componentID()} instead
+     */
+    @Deprecated(forRemoval = true)
     public String getID() {
         return componentID;
     }
 
+    /**
+     * @deprecated Use {@link #componentTopic()} instead
+     */
+    @Deprecated(forRemoval = true)
     public String getDestination() {
         return componentTopic;
     }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
@@ -24,7 +24,7 @@
  */
 package org.bitrepository.client.conversation.selector;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Container for information about a pillar which has been identified and marked as selected for a request.
@@ -40,7 +40,7 @@ public record SelectedComponentInfo(String componentID, String componentTopic) {
     }
 
     @Override
-    public @NotNull String toString() {
+    public @NonNull String toString() {
         return "SelectedComponentInfo: componentID=" + componentID + ", componentTopic=" + componentTopic;
     }
 }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
@@ -51,9 +51,4 @@ public record SelectedComponentInfo(@NonNull String componentID, @NonNull String
     public @NonNull String getDestination() {
         return componentTopic;
     }
-
-    @Override
-    public @NonNull String toString() {
-        return "SelectedComponentInfo: componentID=" + componentID + ", componentTopic=" + componentTopic;
-    }
 }

--- a/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/client/conversation/selector/SelectedComponentInfo.java
@@ -24,46 +24,23 @@
  */
 package org.bitrepository.client.conversation.selector;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
- * Container for information about a pillar which as been identified and are marked as selected for a request.
+ * Container for information about a pillar which has been identified and marked as selected for a request.
  */
-public class SelectedComponentInfo {
-    /**
-     * The ID of the selected pillar
-     */
-    protected final String componentID;
-    /**
-     * The topic for communication with the selected pillar
-     */
-    protected final String componentTopic;
+public record SelectedComponentInfo(String componentID, String componentTopic) {
 
-    /**
-     * @param componentID    The ID of the pillar
-     * @param componentTopic the topic for communication with the selected pillar
-     */
-    public SelectedComponentInfo(String componentID, String componentTopic) {
-        super();
-        this.componentID = componentID;
-        this.componentTopic = componentTopic;
-    }
-
-    /**
-     * @return The ID of the pillar chosen by this selector if finished. If unfinished null is returned
-     */
     public String getID() {
         return componentID;
     }
 
-    /**
-     * @return If finished return the topic for sending messages to the pillar chosen by this selector.
-     * If unfinished null is returned
-     */
     public String getDestination() {
         return componentTopic;
     }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + ": componentID=" + componentID + ", componentTopic=" + componentTopic;
+    public @NotNull String toString() {
+        return "SelectedComponentInfo: componentID=" + componentID + ", componentTopic=" + componentTopic;
     }
 }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/CompleteEventAwaiter.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/CompleteEventAwaiter.java
@@ -56,7 +56,7 @@ public abstract class CompleteEventAwaiter implements EventHandler {
      * @param settings      The settings.
      * @param outputHandler The {@link OutputHandler} for handling outputting results
      */
-    public CompleteEventAwaiter(Settings settings, OutputHandler outputHandler) {
+    protected CompleteEventAwaiter(Settings settings, OutputHandler outputHandler) {
         this.timeout = settings.getIdentificationTimeout().plus(settings.getOperationTimeout());
         this.output = outputHandler;
     }
@@ -88,7 +88,7 @@ public abstract class CompleteEventAwaiter implements EventHandler {
     public OperationEvent getFinish() {
         try {
             CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
-            return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
+            return finalEventQueue.poll(pollTimeout.count(), pollTimeout.unit());
         } catch (InterruptedException e) {
             throw new IllegalStateException("Interrupted while waiting for the final response.", e);
         }

--- a/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/PagingEventHandler.java
+++ b/bitrepository-client/src/main/java/org/bitrepository/commandline/eventhandler/PagingEventHandler.java
@@ -73,7 +73,7 @@ public abstract class PagingEventHandler implements EventHandler {
     public OperationEvent getFinish() {
         try {
             CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
-            return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
+            return finalEventQueue.poll(pollTimeout.count(), pollTimeout.unit());
         } catch (InterruptedException e) {
             throw new IllegalStateException("Interrupted while waiting for the final response.", e);
         }

--- a/bitrepository-client/src/test/java/org/bitrepository/client/conversation/selector/SelectedComponentInfoTest.java
+++ b/bitrepository-client/src/test/java/org/bitrepository/client/conversation/selector/SelectedComponentInfoTest.java
@@ -1,0 +1,32 @@
+package org.bitrepository.client.conversation.selector;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("regressiontest")
+class SelectedComponentInfoTest {
+
+    @Test
+    void delegationMethodsReturnCorrectComponents() {
+        SelectedComponentInfo info = new SelectedComponentInfo("pillar1", "pillar1-topic");
+        assertEquals("pillar1", info.getID());
+        assertEquals("pillar1-topic", info.getDestination());
+    }
+
+    @Test
+    void equalityIsComponentBased() {
+        SelectedComponentInfo a = new SelectedComponentInfo("p1", "t1");
+        SelectedComponentInfo b = new SelectedComponentInfo("p1", "t1");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void toStringContainsComponentValues() {
+        String s = new SelectedComponentInfo("p1", "t1").toString();
+        assertTrue(s.contains("p1"));
+        assertTrue(s.contains("t1"));
+    }
+}

--- a/bitrepository-core/pom.xml
+++ b/bitrepository-core/pom.xml
@@ -84,9 +84,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>23.0.0</version>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-core/src/main/java/org/bitrepository/common/DefaultThreadFactory.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/DefaultThreadFactory.java
@@ -21,7 +21,7 @@
  */
 package org.bitrepository.common;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public class DefaultThreadFactory implements ThreadFactory {
     }
 
     @Override
-    public synchronized Thread newThread(@NotNull Runnable runnable) {
+    public synchronized Thread newThread(@NonNull Runnable runnable) {
         Thread newThread = new Thread(runnable, prefix + "-Thread" + counter);
         newThread.setPriority(priority);
         newThread.setDaemon(daemonic);

--- a/bitrepository-core/src/main/java/org/bitrepository/common/filestore/DefaultFileInfo.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/filestore/DefaultFileInfo.java
@@ -29,12 +29,7 @@ import java.io.InputStream;
 /**
  * File info for the files of a default file system.
  */
-public class DefaultFileInfo implements FileInfo {
-    private final File file;
-
-    public DefaultFileInfo(File file) {
-        this.file = file;
-    }
+public record DefaultFileInfo(File file) implements FileInfo {
 
     @Override
     public String getFileID() {
@@ -54,9 +49,5 @@ public class DefaultFileInfo implements FileInfo {
     @Override
     public long getSize() {
         return file.length();
-    }
-
-    public File getFile() {
-        return file;
     }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/common/filestore/DefaultFileInfo.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/filestore/DefaultFileInfo.java
@@ -31,6 +31,14 @@ import java.io.InputStream;
  */
 public record DefaultFileInfo(File file) implements FileInfo {
 
+    /**
+     * @deprecated Use {@link #file()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public File getFile() {
+        return file;
+    }
+
     @Override
     public String getFileID() {
         return file.getName();

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
@@ -7,4 +7,20 @@ public record CountAndTimeUnit(long count, TimeUnit unit) {
     public CountAndTimeUnit {
         Objects.requireNonNull(unit, "unit");
     }
+
+    /**
+     * @deprecated Use {@link #count()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * @deprecated Use {@link #unit()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public TimeUnit getUnit() {
+        return unit;
+    }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/CountAndTimeUnit.java
@@ -3,33 +3,8 @@ package org.bitrepository.common.utils;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-public class CountAndTimeUnit {
-    private final long count;
-    private final TimeUnit unit;
-
-    public CountAndTimeUnit(long count, TimeUnit unit) {
-        this.count = count;
-        this.unit = Objects.requireNonNull(unit, "unit");
-    }
-
-    public long getCount() {
-        return count;
-    }
-
-    public TimeUnit getUnit() {
-        return unit;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CountAndTimeUnit that = (CountAndTimeUnit) o;
-        return count == that.count && unit == that.unit;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(count, unit);
+public record CountAndTimeUnit(long count, TimeUnit unit) {
+    public CountAndTimeUnit {
+        Objects.requireNonNull(unit, "unit");
     }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/common/utils/TimeUtils.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/common/utils/TimeUtils.java
@@ -22,7 +22,7 @@
 package org.bitrepository.common.utils;
 
 import org.bitrepository.common.ArgumentValidator;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.text.DateFormat;
@@ -191,7 +191,7 @@ public final class TimeUtils {
         return humanPeriodAndDuration(periodBetween, durationBetween);
     }
 
-    @NotNull
+    @NonNull
     private static String humanPeriodAndDuration(Period period, Duration dur) {
         // Round duration to whole minutes
         dur = dur.plusSeconds(30).truncatedTo(ChronoUnit.MINUTES);

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/MessageContext.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/MessageContext.java
@@ -24,4 +24,12 @@ package org.bitrepository.protocol;
 /**
  * Contains information about the message, not contained in the message itself.
  */
-public record MessageContext(String certificateFingerprint) {}
+public record MessageContext(String certificateFingerprint) {
+    /**
+     * @deprecated Use {@link #certificateFingerprint()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public String getCertificateFingerprint() {
+        return certificateFingerprint;
+    }
+}

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/MessageContext.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/MessageContext.java
@@ -24,14 +24,4 @@ package org.bitrepository.protocol;
 /**
  * Contains information about the message, not contained in the message itself.
  */
-public class MessageContext {
-    private final String certificateFingerprint;
-
-    public MessageContext(String certificateFingerprint) {
-        this.certificateFingerprint = certificateFingerprint;
-    }
-
-    public String getCertificateFingerprint() {
-        return certificateFingerprint;
-    }
-}
+public record MessageContext(String certificateFingerprint) {}

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
@@ -53,4 +53,20 @@ public record CertificateID(X500Principal issuer, BigInteger serial) {
     public static CertificateID of(X500Name issuer, BigInteger serialNumber) {
         return new CertificateID(issuer, serialNumber);
     }
+
+    /**
+     * @deprecated Use {@link #issuer()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public X500Principal getIssuer() {
+        return issuer;
+    }
+
+    /**
+     * @deprecated Use {@link #serial()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public BigInteger getSerial() {
+        return serial;
+    }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
@@ -28,80 +28,19 @@ import java.io.IOException;
 import java.math.BigInteger;
 
 /**
- * Class to be used as an identifier of certificates.
- * Identification is based on the issuer (X500Principal) and the certificates serial number.
- * Those combined should provide a unique ID, and the information can be extracted from a signature.
+ * Identifies a certificate by issuer (X500Principal) and serial number.
+ * Those combined provide a unique ID extractable from a signature.
  */
-public class CertificateID {
-    private final X500Principal issuer;
-    private final BigInteger serial;
+public record CertificateID(X500Principal issuer, BigInteger serial) {
 
     /**
-     * @param issuer       The X500Principal object that identifies the certificate issuer.
-     *                     Can be extracted from a SignerID and a X509Certificate
-     * @param serialNumber The certificates SerialNumber, ca be extracted from a SignerID and a X509Certificate
+     * Creates a CertificateID from an X500Name issuer, converting it to X500Principal.
      */
-    public CertificateID(X500Principal issuer, BigInteger serialNumber) {
-        this.issuer = issuer;
-        this.serial = serialNumber;
-    }
-
-    public CertificateID(X500Name issuer, BigInteger serialNumber) {
+    public static CertificateID of(X500Name issuer, BigInteger serialNumber) {
         try {
-            this.issuer = new X500Principal(issuer.getEncoded());
+            return new CertificateID(new X500Principal(issuer.getEncoded()), serialNumber);
         } catch (IOException e) {
             throw new RuntimeException("Failed to create X500Principal from X500Name", e);
         }
-        this.serial = serialNumber;
     }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((issuer == null) ? 0 : issuer.hashCode());
-        result = prime * result + ((serial == null) ? 0 : serial.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CertificateID other = (CertificateID) obj;
-        if (issuer == null) {
-            if (other.issuer != null)
-                return false;
-        } else if (!issuer.equals(other.issuer))
-            return false;
-        if (serial == null) {
-            return other.serial == null;
-        } else return serial.equals(other.serial);
-    }
-
-    @Override
-    public String toString() {
-        return "CertificateID [issuer=" + issuer + ", serial=" + serial + "]";
-    }
-
-    /**
-     * @return Identifying object of the issuer of a certificate
-     * @see CertificateID constructor
-     */
-    public X500Principal getIssuer() {
-        return issuer;
-    }
-
-    /**
-     * @return The serial number of a certificate (unique within an issuer)
-     * @see CertificateID constructor
-     */
-    public BigInteger getSerial() {
-        return serial;
-    }
-
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/security/CertificateID.java
@@ -25,6 +25,7 @@ import org.bouncycastle.asn1.x500.X500Name;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 
 /**
@@ -33,14 +34,23 @@ import java.math.BigInteger;
  */
 public record CertificateID(X500Principal issuer, BigInteger serial) {
 
+    /** Creates a CertificateID from an X500Name issuer converting it to X500Principal. */
+    public CertificateID(X500Name issuer, BigInteger serialNumber) {
+        this(getX500Principal(issuer), serialNumber);
+    }
+
+    private static X500Principal getX500Principal(X500Name issuer) {
+        try {
+            return new X500Principal(issuer.getEncoded());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create X500Principal from X500Name", e);
+        }
+    }
+
     /**
      * Creates a CertificateID from an X500Name issuer, converting it to X500Principal.
      */
     public static CertificateID of(X500Name issuer, BigInteger serialNumber) {
-        try {
-            return new CertificateID(new X500Principal(issuer.getEncoded()), serialNumber);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create X500Principal from X500Name", e);
-        }
+        return new CertificateID(issuer, serialNumber);
     }
 }

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/security/PermissionStore.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/security/PermissionStore.java
@@ -133,7 +133,7 @@ public class PermissionStore {
      * @throws PermissionStoreException if no certificate can be found based on the SignerId
      */
     public X509Certificate getCertificate(SignerId signer) throws PermissionStoreException {
-        CertificateID certificateID = new CertificateID(signer.getIssuer(), signer.getSerialNumber());
+        CertificateID certificateID = CertificateID.of(signer.getIssuer(), signer.getSerialNumber());
         CertificatePermission permission = permissionMap.get(certificateID);
         if (permission != null) {
             return permission.getCertificate();
@@ -150,7 +150,7 @@ public class PermissionStore {
      * @throws PermissionStoreException in case no certificate has been registered for the given signerId
      */
     public boolean checkCertificateUser(SignerId signer, String certificateUser) throws PermissionStoreException {
-        CertificateID certificateID = new CertificateID(signer.getIssuer(), signer.getSerialNumber());
+        CertificateID certificateID = CertificateID.of(signer.getIssuer(), signer.getSerialNumber());
         CertificatePermission certificatePermission = permissionMap.get(certificateID);
         if (certificatePermission == null) {
             throw new PermissionStoreException("Failed to find certificate and permissions for the requested signer: " + certificateID);
@@ -165,7 +165,7 @@ public class PermissionStore {
      * @throws UnregisteredPermissionException No finger-print could be found for the indicated signer.
      */
     public String getCertificateFingerprint(SignerId signer) throws UnregisteredPermissionException {
-        CertificateID certificateID = new CertificateID(signer.getIssuer(), signer.getSerialNumber());
+        CertificateID certificateID = CertificateID.of(signer.getIssuer(), signer.getSerialNumber());
         CertificatePermission certificatePermission = permissionMap.get(certificateID);
         if (certificatePermission != null) {
             return certificatePermission.getFingerprint();
@@ -185,7 +185,7 @@ public class PermissionStore {
      * @throws PermissionStoreException in case no certificate and permission set can be found for the provided signer.
      */
     public boolean checkPermission(SignerId signer, Operation permission, String collectionID) throws PermissionStoreException {
-        CertificateID certificateID = new CertificateID(signer.getIssuer(), signer.getSerialNumber());
+        CertificateID certificateID = CertificateID.of(signer.getIssuer(), signer.getSerialNumber());
         CertificatePermission certificatePermission = permissionMap.get(certificateID);
         if (certificatePermission == null) {
             throw new PermissionStoreException("Failed to find certificate and permissions for the requested signer: " + certificateID);

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/CountAndTimeUnitTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/CountAndTimeUnitTest.java
@@ -1,0 +1,39 @@
+package org.bitrepository.common.utils;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("regressiontest")
+class CountAndTimeUnitTest {
+
+    @Test
+    void accessorsReturnConstructorValues() {
+        CountAndTimeUnit c = new CountAndTimeUnit(42, TimeUnit.SECONDS);
+        assertEquals(42, c.count());
+        assertEquals(TimeUnit.SECONDS, c.unit());
+    }
+
+    @Test
+    void compactConstructorRejectsNullUnit() {
+        assertThrows(NullPointerException.class, () -> new CountAndTimeUnit(1, null));
+    }
+
+    @Test
+    void equalityIsComponentBased() {
+        CountAndTimeUnit a = new CountAndTimeUnit(5, TimeUnit.MINUTES);
+        CountAndTimeUnit b = new CountAndTimeUnit(5, TimeUnit.MINUTES);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void inequalityOnDifferentComponents() {
+        CountAndTimeUnit base = new CountAndTimeUnit(5, TimeUnit.MINUTES);
+        assertNotEquals(base, new CountAndTimeUnit(6, TimeUnit.MINUTES));
+        assertNotEquals(base, new CountAndTimeUnit(5, TimeUnit.SECONDS));
+    }
+}

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/TimeUtilsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/TimeUtilsTest.java
@@ -243,8 +243,8 @@ class TimeUtilsTest {
     @Tag("regressiontest")
     void convertsDurationToCountAndTimeUnit() {
         CountAndTimeUnit expectedZero = TimeUtils.durationToCountAndTimeUnit(Duration.ZERO);
-        Assertions.assertEquals(0, expectedZero.getCount());
-        Assertions.assertNotNull(expectedZero.getUnit());
+        Assertions.assertEquals(0, expectedZero.count());
+        Assertions.assertNotNull(expectedZero.unit());
 
         Assertions.assertEquals(new CountAndTimeUnit(1, TimeUnit.NANOSECONDS),
                 TimeUtils.durationToCountAndTimeUnit(Duration.ofNanos(1)));

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/security/CertificateIDTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/security/CertificateIDTest.java
@@ -58,7 +58,7 @@ class CertificateIDTest {
         CMSSignedData s = new CMSSignedData(new CMSProcessableByteArray(
                 SecurityTestConstants.getTestData().getBytes(SecurityModuleConstants.defaultEncodingType)), decodeSig);
         SignerInformation signer = s.getSignerInfos().getSigners().iterator().next();
-        CertificateID certificateIDFromSignature = new CertificateID(signer.getSID().getIssuer(), signer.getSID().getSerialNumber());
+        CertificateID certificateIDFromSignature = CertificateID.of(signer.getSID().getIssuer(), signer.getSID().getSerialNumber());
 
         addStep("Assert that the two CertificateID objects are equal", "Assert succeeds");
         Assertions.assertEquals(certificateIDfromCertificate, certificateIDFromSignature);
@@ -81,7 +81,7 @@ class CertificateIDTest {
         CMSSignedData s = new CMSSignedData(new CMSProcessableByteArray(
                 SecurityTestConstants.getTestData().getBytes(SecurityModuleConstants.defaultEncodingType)), decodeSig);
         SignerInformation signer = s.getSignerInfos().getSigners().iterator().next();
-        CertificateID certificateIDFromSignature = new CertificateID(signer.getSID().getIssuer(), signer.getSID().getSerialNumber());
+        CertificateID certificateIDFromSignature = CertificateID.of(signer.getSID().getIssuer(), signer.getSID().getSerialNumber());
 
         addStep("Assert that the two CertificateID objects are not equal", "Assert succeeds");
         Assertions.assertNotSame(certificateIDFromCertificate, certificateIDFromSignature);
@@ -100,8 +100,8 @@ class CertificateIDTest {
         CertificateID certificateID1 = new CertificateID(issuer, serial);
 
         addStep("Validate the content of the certificateID", "Should be same as x509Certificate");
-        Assertions.assertEquals(issuer, certificateID1.getIssuer());
-        Assertions.assertEquals(serial, certificateID1.getSerial());
+        Assertions.assertEquals(issuer, certificateID1.issuer());
+        Assertions.assertEquals(serial, certificateID1.serial());
 
         addStep("Test whether it equals it self", "should give positive result");
         Assertions.assertEquals(certificateID1, certificateID1);

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionMetric.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionMetric.java
@@ -3,42 +3,18 @@ package org.bitrepository.integrityservice.cache;
 import java.time.Instant;
 
 /**
- * Class to carry information of collection specific pillar metrics.
- * The class exists as java is not able to handle simple tuples,
- * so the class is meant to carry data in a specific context.
+ * Carries collection-specific pillar metrics.
  *
  * @see org.bitrepository.integrityservice.cache.database.IntegrityDAO#getPillarCollectionMetrics(String)
  */
-public class PillarCollectionMetric {
+public record PillarCollectionMetric(long pillarCollectionSize, long pillarFileCount, Instant oldestChecksumTimestamp) {
 
-    /**
-     * The summed size of the files in a collection on the pillar.
-     */
-    private final long pillarCollectionSize;
-
-    /**
-     * The count of files present in a collection on a pillar
-     */
-    private final long pillarFileCount;
-
-    /** Timestamp of the oldest checksum on the pillar or null if no checksums yet */
-    private final Instant oldestChecksumTimestamp;
-
+    /** Convenience constructor that treats null sizes/counts as zero. */
     public PillarCollectionMetric(Long pillarCollectionSize, Long pillarFileCount, Instant oldestChecksumTimestamp) {
-        this.pillarCollectionSize = pillarCollectionSize == null ? 0 : pillarCollectionSize;
-        this.pillarFileCount = pillarFileCount == null ? 0 : pillarFileCount;
-        this.oldestChecksumTimestamp = oldestChecksumTimestamp;
-    }
-
-    public long getPillarCollectionSize() {
-        return pillarCollectionSize;
-    }
-
-    public long getPillarFileCount() {
-        return pillarFileCount;
-    }
-
-    public Instant getOldestChecksumTimestamp() {
-        return oldestChecksumTimestamp;
+        this(
+            pillarCollectionSize == null ? 0L : pillarCollectionSize,
+            pillarFileCount == null ? 0L : pillarFileCount,
+            oldestChecksumTimestamp
+        );
     }
 }

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionMetric.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionMetric.java
@@ -5,6 +5,9 @@ import java.time.Instant;
 /**
  * Carries collection-specific pillar metrics.
  *
+ * @param pillarCollectionSize    The summed size of the files in a collection on the pillar.
+ * @param pillarFileCount         The count of files present in a collection on a pillar.
+ * @param oldestChecksumTimestamp Timestamp of the oldest checksum on the pillar, or null if no checksums yet.
  * @see org.bitrepository.integrityservice.cache.database.IntegrityDAO#getPillarCollectionMetrics(String)
  */
 public record PillarCollectionMetric(long pillarCollectionSize, long pillarFileCount, Instant oldestChecksumTimestamp) {
@@ -16,5 +19,29 @@ public record PillarCollectionMetric(long pillarCollectionSize, long pillarFileC
             pillarFileCount == null ? 0L : pillarFileCount,
             oldestChecksumTimestamp
         );
+    }
+
+    /**
+     * @deprecated Use {@link #pillarCollectionSize()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public long getPillarCollectionSize() {
+        return pillarCollectionSize;
+    }
+
+    /**
+     * @deprecated Use {@link #pillarFileCount()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public long getPillarFileCount() {
+        return pillarFileCount;
+    }
+
+    /**
+     * @deprecated Use {@link #oldestChecksumTimestamp()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public Instant getOldestChecksumTimestamp() {
+        return oldestChecksumTimestamp;
     }
 }

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionStat.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/PillarCollectionStat.java
@@ -22,7 +22,7 @@
 package org.bitrepository.integrityservice.cache;
 
 import org.bitrepository.common.utils.TimeUtils;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -189,7 +189,7 @@ public class PillarCollectionStat {
     }
 
     /** @return Human-readable age of the oldest checksum, for example "3m 46s" */
-    @NotNull
+    @NonNull
     public String getAgeOfOldestChecksum() {
         if (oldestChecksumTimestamp == null) {
             return "N/A";

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/database/IntegrityDAO.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/cache/database/IntegrityDAO.java
@@ -36,7 +36,7 @@ import org.bitrepository.integrityservice.workflow.step.HandleObsoleteChecksumsS
 import org.bitrepository.service.database.DBConnector;
 import org.bitrepository.service.database.DatabaseUtils;
 import org.bitrepository.settings.referencesettings.ObsoleteChecksumSettings;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -644,7 +644,7 @@ public abstract class IntegrityDAO {
         return stats;
     }
 
-    @NotNull
+    @NonNull
     private String getMaxAgeForChecksums(String pillarID) {
         ObsoleteChecksumSettings obsoleteChecksumSettings =
                 SettingsUtils.getIntegrityServiceSettings().getObsoleteChecksumSettings();

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/checking/MaxChecksumAgeProvider.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/checking/MaxChecksumAgeProvider.java
@@ -34,13 +34,10 @@ import java.util.Objects;
 /**
  * Provide easy access to the MaxChecksumAge for individual pillars.
  */
-public class MaxChecksumAgeProvider {
-    private final Duration defaultMaxAge;
-    private final ObsoleteChecksumSettings settings;
+public record MaxChecksumAgeProvider(Duration defaultMaxAge, ObsoleteChecksumSettings settings) {
 
-    public MaxChecksumAgeProvider(Duration defaultMaxAge, ObsoleteChecksumSettings settings) {
-        this.defaultMaxAge = Objects.requireNonNull(defaultMaxAge, "defaultMaxAge");
-        this.settings = settings;
+    public MaxChecksumAgeProvider {
+        Objects.requireNonNull(defaultMaxAge, "defaultMaxAge");
     }
 
     /**

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityCollectorEventHandler.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityCollectorEventHandler.java
@@ -94,7 +94,7 @@ public class IntegrityCollectorEventHandler implements EventHandler {
      */
     public OperationEvent getFinish() throws InterruptedException {
         CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
-        return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
+        return finalEventQueue.poll(pollTimeout.count(), pollTimeout.unit());
     }
 
     /**

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/IntegrityEventCompleteAwaiter.java
@@ -79,7 +79,7 @@ public class IntegrityEventCompleteAwaiter implements EventHandler {
     public OperationEvent getFinish() {
         try {
             CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
-            return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
+            return finalEventQueue.poll(pollTimeout.count(), pollTimeout.unit());
         } catch (InterruptedException e) {
             throw new IllegalStateException("Interrupted while waiting for the final response.", e);
         }

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/SimpleChecksumEventHandler.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/collector/SimpleChecksumEventHandler.java
@@ -90,7 +90,7 @@ public class SimpleChecksumEventHandler implements EventHandler {
      */
     public OperationEvent getFinish() throws InterruptedException {
         CountAndTimeUnit pollTimeout = TimeUtils.durationToCountAndTimeUnit(timeout);
-        return finalEventQueue.poll(pollTimeout.getCount(), pollTimeout.getUnit());
+        return finalEventQueue.poll(pollTimeout.count(), pollTimeout.unit());
     }
 
     /**

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/web/RestIntegrityService.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/web/RestIntegrityService.java
@@ -311,7 +311,7 @@ public class RestIntegrityService {
     public List<String> getWorkflowList(@QueryParam("collectionID") String collectionID) {
         List<String> workflowIDs = new ArrayList<>();
         for (JobID workflowID : workflowManager.getWorkflows(collectionID)) {
-            workflowIDs.add(workflowID.getWorkflowName());
+            workflowIDs.add(workflowID.workflowName());
         }
         return workflowIDs;
     }
@@ -595,7 +595,7 @@ public class RestIntegrityService {
         Workflow workflow = workflowManager.getWorkflow(workflowID);
         WorkflowStatistic lastRunStatistic = workflowManager.getLastCompleteStatistics(workflowID);
         jg.writeStartObject();
-        jg.writeObjectField("workflowID", workflowID.getWorkflowName());
+        jg.writeObjectField("workflowID", workflowID.workflowName());
         jg.writeObjectField("workflowDescription", workflow.getDescription());
         Instant nextScheduledRun = workflowManager.getNextScheduledRunInstant(workflowID);
         if (nextScheduledRun == null) {

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/CompleteIntegrityCheck.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/CompleteIntegrityCheck.java
@@ -46,15 +46,15 @@ public class CompleteIntegrityCheck extends IntegrityCheckWorkflow {
 
     @Override
     protected UpdateFileIDsStep getUpdateFileIDsStep() {
-        return new FullUpdateFileIDsStep(context.getCollector(), context.getStore(), context.getAlerter(),
-                context.getSettings(), collectionID, integrityContributors);
+        return new FullUpdateFileIDsStep(context.collector(), context.store(), context.alerter(),
+                context.settings(), collectionID, integrityContributors);
     }
 
 
     @Override
     protected UpdateChecksumsStep getUpdateChecksumsStep() {
-        return new FullUpdateChecksumsStep(context.getCollector(), context.getStore(), context.getAlerter(),
-                ChecksumUtils.getDefault(context.getSettings()), context.getSettings(), collectionID,
+        return new FullUpdateChecksumsStep(context.collector(), context.store(), context.alerter(),
+                ChecksumUtils.getDefault(context.settings()), context.settings(), collectionID,
                 integrityContributors);
     }
 

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IncrementalIntegrityCheck.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IncrementalIntegrityCheck.java
@@ -45,14 +45,14 @@ public class IncrementalIntegrityCheck extends IntegrityCheckWorkflow {
 
     @Override
     protected UpdateFileIDsStep getUpdateFileIDsStep() {
-        return new IncrementalUpdateFileIDsStep(context.getCollector(), context.getStore(), context.getAlerter(), context.getSettings(),
+        return new IncrementalUpdateFileIDsStep(context.collector(), context.store(), context.alerter(), context.settings(),
                 collectionID, integrityContributors);
     }
 
     @Override
     protected UpdateChecksumsStep getUpdateChecksumsStep() {
-        return new IncrementalUpdateChecksumsStep(context.getCollector(), context.getStore(), context.getAlerter(),
-                ChecksumUtils.getDefault(context.getSettings()), context.getSettings(), collectionID, integrityContributors);
+        return new IncrementalUpdateChecksumsStep(context.collector(), context.store(), context.alerter(),
+                ChecksumUtils.getDefault(context.settings()), context.settings(), collectionID, integrityContributors);
     }
 
     @Override

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityCheckWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityCheckWorkflow.java
@@ -66,7 +66,7 @@ public abstract class IntegrityCheckWorkflow extends Workflow {
     /**
      * Remember to call the initialise method needs to be called before the start method.
      */
-    public IntegrityCheckWorkflow() {}
+    protected IntegrityCheckWorkflow() {}
 
     @Override
     public void initialise(WorkflowContext context, String collectionID) {
@@ -84,20 +84,20 @@ public abstract class IntegrityCheckWorkflow extends Workflow {
     protected abstract Instant getChecksumUpdateCutoffDate();
 
     @Override
-    public void start() {
+    public synchronized void start() {
         workflowStart = Instant.now();
 
         if (context == null) {
             throw new IllegalStateException(
                     "The workflow can not be started before the initialise method has been " + "called.");
         }
-        IntegrityReporter reporter = new BasicIntegrityReporter(jobID.getCollectionID(), jobID.getWorkflowName(),
+        IntegrityReporter reporter = new BasicIntegrityReporter(jobID.collectionID(), jobID.workflowName(),
                 IntegrityServiceManager.getIntegrityReportStorageDir());
 
         super.start();
         try {
             StatisticsCollector statisticsCollector = new StatisticsCollector(collectionID);
-            Integer maxRetries = context.getSettings().getReferenceSettings().getIntegrityServiceSettings()
+            Integer maxRetries = context.settings().getReferenceSettings().getIntegrityServiceSettings()
                     .getComponentRetries();
             integrityContributors = new IntegrityContributors(SettingsUtils.getPillarIDsForCollection(collectionID),
                     maxRetries == null ? DEFAULT_MAX_RETRIES : maxRetries);
@@ -111,38 +111,38 @@ public abstract class IntegrityCheckWorkflow extends Workflow {
             performStep(updateChecksumStep);
 
             if (cleanDeletedFiles()) {
-                HandleDeletedFilesStep handleDeletedFilesStep = new HandleDeletedFilesStep(context.getStore(), reporter,
+                HandleDeletedFilesStep handleDeletedFilesStep = new HandleDeletedFilesStep(context.store(), reporter,
                         workflowStart, integrityContributors.getFinishedContributors());
                 performStep(handleDeletedFilesStep);
             }
 
             statisticsCollector.getCollectionStat().setStatsTime(Instant.now());
-            javax.xml.datatype.Duration timeBeforeMissingFileCheck = context.getSettings().getReferenceSettings()
+            javax.xml.datatype.Duration timeBeforeMissingFileCheck = context.settings().getReferenceSettings()
                     .getIntegrityServiceSettings().getTimeBeforeMissingFileCheck();
             Duration missingFileGracePeriod = XmlUtils.xmlDurationToDuration(timeBeforeMissingFileCheck);
-            HandleMissingFilesStep handleMissingFilesStep = new HandleMissingFilesStep(context.getStore(), reporter,
+            HandleMissingFilesStep handleMissingFilesStep = new HandleMissingFilesStep(context.store(), reporter,
                     statisticsCollector, missingFileGracePeriod);
             performStep(handleMissingFilesStep);
 
             HandleChecksumValidationStep handleChecksumValidationStep = new HandleChecksumValidationStep(
-                    context.getStore(), context.getAuditManager(), reporter, statisticsCollector);
+                    context.store(), context.auditManager(), reporter, statisticsCollector);
             performStep(handleChecksumValidationStep);
 
-            HandleMissingChecksumsStep handleMissingChecksumsStep = new HandleMissingChecksumsStep(context.getStore(),
+            HandleMissingChecksumsStep handleMissingChecksumsStep = new HandleMissingChecksumsStep(context.store(),
                     reporter, statisticsCollector, getChecksumUpdateCutoffDate());
             performStep(handleMissingChecksumsStep);
 
             HandleObsoleteChecksumsStep handleObsoleteChecksumsStep = new HandleObsoleteChecksumsStep(
-                    context.getSettings(), context.getStore(), reporter, statisticsCollector);
+                    context.settings(), context.store(), reporter, statisticsCollector);
             performStep(handleObsoleteChecksumsStep);
 
-            CreateStatisticsEntryStep createStatistics = new CreateStatisticsEntryStep(context.getStore(), collectionID,
+            CreateStatisticsEntryStep createStatistics = new CreateStatisticsEntryStep(context.store(), collectionID,
                     statisticsCollector);
             performStep(createStatistics);
 
             if (currentState() != WorkflowState.ABORTED) {
                 if (reporter.hasIntegrityIssues()) {
-                    context.getAlerter().integrityFailed(reporter.generateSummaryOfReport(), collectionID);
+                    context.alerter().integrityFailed(reporter.generateSummaryOfReport(), collectionID);
                 }
                 try {
                     reporter.generateReport();
@@ -150,7 +150,7 @@ public abstract class IntegrityCheckWorkflow extends Workflow {
                             .setLatestReport(collectionID, reporter.getReportDir());
                 } catch (IOException e) {
                     log.error("Failed to generate integrity report", e);
-                    context.getAlerter().integrityComponentFailure("Failed to generate integrity report", collectionID);
+                    context.alerter().integrityComponentFailure("Failed to generate integrity report", collectionID);
                 }
             }
         } finally {

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowContext.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowContext.java
@@ -38,4 +38,45 @@ public record IntegrityWorkflowContext(
     IntegrityModel store,
     IntegrityAlerter alerter,
     AuditTrailManager auditManager
-) implements WorkflowContext {}
+) implements WorkflowContext {
+
+    /**
+     * @deprecated Use {@link #settings()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public Settings getSettings() {
+        return settings;
+    }
+
+    /**
+     * @deprecated Use {@link #collector()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public IntegrityInformationCollector getCollector() {
+        return collector;
+    }
+
+    /**
+     * @deprecated Use {@link #store()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public IntegrityModel getStore() {
+        return store;
+    }
+
+    /**
+     * @deprecated Use {@link #alerter()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public IntegrityAlerter getAlerter() {
+        return alerter;
+    }
+
+    /**
+     * @deprecated Use {@link #auditManager()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public AuditTrailManager getAuditManager() {
+        return auditManager;
+    }
+}

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowContext.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowContext.java
@@ -30,64 +30,12 @@ import org.bitrepository.service.audit.AuditTrailManager;
 import org.bitrepository.service.workflow.WorkflowContext;
 
 /**
- * Contains the general data needed by a integrity workflow. The class wraps a number of objects normally
- * needed by integrity workflows. This avoids complicated methods with lots a arguments.
+ * Contains the general data needed by an integrity workflow, avoiding methods with many arguments.
  */
-public class IntegrityWorkflowContext implements WorkflowContext {
-    private final Settings settings;
-    private final IntegrityInformationCollector collector;
-    private final IntegrityModel store;
-    private final IntegrityAlerter alerter;
-    private final AuditTrailManager auditManager;
-
-    /**
-     * @param settings     The <code>Settings</code> to use in the workflow.
-     * @param collector    The <code>IntegrityInformationCollector</code> to use in the workflow.
-     * @param store        The <code>IntegrityModel</code> to use in the workflow.
-     * @param alerter      The <code>IntegrityAlerter</code> to use in the workflow.
-     * @param auditManager The <code>AuditTrailManager</code> to use in the workflow.
-     */
-    public IntegrityWorkflowContext(Settings settings,
-                                    IntegrityInformationCollector collector,
-                                    IntegrityModel store,
-                                    IntegrityAlerter alerter,
-                                    AuditTrailManager auditManager) {
-        this.settings = settings;
-        this.collector = collector;
-        this.store = store;
-        this.alerter = alerter;
-        this.auditManager = auditManager;
-
-    }
-
-    public Settings getSettings() {
-        return settings;
-    }
-
-    public IntegrityInformationCollector getCollector() {
-        return collector;
-    }
-
-    public IntegrityModel getStore() {
-        return store;
-    }
-
-    public IntegrityAlerter getAlerter() {
-        return alerter;
-    }
-
-    public AuditTrailManager getAuditManager() {
-        return auditManager;
-    }
-
-    @Override
-    public String toString() {
-        return "IntegrityWorkflowContext{" +
-                "settings=" + settings +
-                ", collector=" + collector +
-                ", store=" + store +
-                ", alerter=" + alerter +
-                ", auditManager=" + auditManager + '\'' +
-                '}';
-    }
-}
+public record IntegrityWorkflowContext(
+    Settings settings,
+    IntegrityInformationCollector collector,
+    IntegrityModel store,
+    IntegrityAlerter alerter,
+    AuditTrailManager auditManager
+) implements WorkflowContext {}

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowManager.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/IntegrityWorkflowManager.java
@@ -43,7 +43,7 @@ public class IntegrityWorkflowManager extends WorkflowManager {
     public static final long HOURLY = 3_600_000;
 
     public IntegrityWorkflowManager(IntegrityWorkflowContext context, JobScheduler scheduler) {
-        super(context, getWorkflowSettings(context.getSettings()), scheduler);
+        super(context, getWorkflowSettings(context.settings()), scheduler);
     }
 
     private static WorkflowSettings getWorkflowSettings(Settings settings) {

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/RepairMissingFilesWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/RepairMissingFilesWorkflow.java
@@ -96,7 +96,7 @@ public class RepairMissingFilesWorkflow extends Workflow {
      */
     private void repairMissingFiles(List<String> pillarIDs) {
         List<String> filesNotRepaired = new ArrayList<>();
-        try (IntegrityIssueIterator iterator = context.getStore()
+        try (IntegrityIssueIterator iterator = context.store()
                 .findFilesWithMissingCopies(collectionID, pillarIDs.size(), 0L, MAX_RESULTS)) {
 
             String fileId;
@@ -121,7 +121,7 @@ public class RepairMissingFilesWorkflow extends Workflow {
             }
         }
         if (!filesNotRepaired.isEmpty()) {
-            context.getAlerter().operationFailed("Failed to repair the files '" + filesNotRepaired + "'.", collectionID);
+            context.alerter().operationFailed("Failed to repair the files '" + filesNotRepaired + "'.", collectionID);
         }
     }
 
@@ -134,7 +134,7 @@ public class RepairMissingFilesWorkflow extends Workflow {
      */
     private String getChecksumForFile(String fileId) {
         String res = null;
-        for (FileInfo fi : context.getStore().getFileInfos(fileId, collectionID)) {
+        for (FileInfo fi : context.store().getFileInfos(fileId, collectionID)) {
             if (res == null) {
                 res = fi.getChecksum();
             } else {
@@ -159,7 +159,7 @@ public class RepairMissingFilesWorkflow extends Workflow {
      * @throws MalformedURLException If a well-formed URL cannot be created.
      */
     private URL createURL(String fileId) throws MalformedURLException {
-        FileExchange fe = ProtocolComponentFactory.getInstance().getFileExchange(context.getSettings());
+        FileExchange fe = ProtocolComponentFactory.getInstance().getFileExchange(context.settings());
         return fe.getURL(fileId);
     }
 
@@ -201,7 +201,7 @@ public class RepairMissingFilesWorkflow extends Workflow {
      * @throws URISyntaxException If the URL is invalid.
      */
     private void deleteUrl(URL url) throws URISyntaxException {
-        FileExchange fe = ProtocolComponentFactory.getInstance().getFileExchange(context.getSettings());
+        FileExchange fe = ProtocolComponentFactory.getInstance().getFileExchange(context.settings());
         try {
             fe.deleteFile(url);
         } catch (IOException e) {

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/SaltedChecksumWorkflow.java
@@ -92,7 +92,7 @@ public class SaltedChecksumWorkflow extends Workflow {
             Map<String, String> checksums = requestSaltedChecksumForFileStep();
             validateChecksums(checksums);
         } catch (IllegalStateException e) {
-            context.getAlerter().integrityFailed("Failed trying to check salted checksum: " + e.getMessage(),
+            context.alerter().integrityFailed("Failed trying to check salted checksum: " + e.getMessage(),
                     collectionID);
         } finally {
             finish();
@@ -108,7 +108,7 @@ public class SaltedChecksumWorkflow extends Workflow {
      */
     private ChecksumSpecTYPE getChecksumSpecWithRandomSalt() throws IllegalArgumentException {
         ChecksumType defaultChecksum = ChecksumType.valueOf(
-                context.getSettings().getRepositorySettings().getProtocolSettings().getDefaultChecksumType());
+                context.settings().getRepositorySettings().getProtocolSettings().getDefaultChecksumType());
         ChecksumSpecTYPE res = new ChecksumSpecTYPE();
         switch (defaultChecksum) {
             case SHA1:
@@ -144,12 +144,12 @@ public class SaltedChecksumWorkflow extends Workflow {
      * @return The randomly found FileID.
      */
     private String getRandomFileId() {
-        long numberOfFiles = context.getStore().getNumberOfFilesInCollection(collectionID);
+        long numberOfFiles = context.store().getNumberOfFilesInCollection(collectionID);
         if (numberOfFiles <= 0L) {
             throw new IllegalStateException("No files in collection '" + collectionID + "'.");
         }
         long randomFileIndex = ThreadLocalRandom.current().nextLong(numberOfFiles);
-        return context.getStore().getFileIDAtPosition(collectionID, randomFileIndex);
+        return context.store().getFileIDAtPosition(collectionID, randomFileIndex);
     }
 
     /**
@@ -159,8 +159,8 @@ public class SaltedChecksumWorkflow extends Workflow {
      */
     private Map<String, String> requestSaltedChecksumForFileStep() {
         log.info("Request the file '{}' with the checksumSpecTYPE '{}'", currentFileID, currentChecksumSpec);
-        GetChecksumForFileStep step = new GetChecksumForFileStep(context.getCollector(), context.getAlerter(),
-                currentChecksumSpec, currentFileID, context.getSettings(), collectionID, integrityContributors);
+        GetChecksumForFileStep step = new GetChecksumForFileStep(context.collector(), context.alerter(),
+                currentChecksumSpec, currentFileID, context.settings(), collectionID, integrityContributors);
         performStep(step);
         return step.getResults();
     }
@@ -193,7 +193,7 @@ public class SaltedChecksumWorkflow extends Workflow {
                     Base16Utils.decodeBase16(currentChecksumSpec.getChecksumSalt()) + "' for pillars: " +
                     checksums.keySet();
             log.info(audit);
-            context.getAuditManager()
+            context.auditManager()
                     .addAuditEvent(collectionID, currentFileID, "IntegrityServiceWorkflow: " + getClass().getName(),
                             audit, "Integrity salted checksum check", FileAction.INTEGRITY_CHECK, null, null);
         }
@@ -206,10 +206,10 @@ public class SaltedChecksumWorkflow extends Workflow {
      */
     private void sendFailure(String failureMessage) {
         log.warn("Failure in checksum salted checksum: {}", failureMessage);
-        context.getAuditManager()
+        context.auditManager()
                 .addAuditEvent(collectionID, currentFileID, "IntegrityServiceWorkflow: " + getClass().getName(),
                         failureMessage,"Integrity salted checksum check", FileAction.INTEGRITY_CHECK, null, null);
-        context.getAlerter().integrityFailed(failureMessage, collectionID);
+        context.alerter().integrityFailed(failureMessage, collectionID);
     }
 
     @Override

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/CreateStatisticsEntryStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/CreateStatisticsEntryStep.java
@@ -63,14 +63,14 @@ public class CreateStatisticsEntryStep extends AbstractWorkFlowStep {
                 sc.getPillarCollectionStat(pillar).setDataSize(0L);
                 sc.getPillarCollectionStat(pillar).setOldestChecksumTimestamp(null);
             } else {
-                sc.getPillarCollectionStat(pillar).setFileCount(metric.getPillarFileCount());
-                sc.getPillarCollectionStat(pillar).setDataSize(metric.getPillarCollectionSize());
-                sc.getPillarCollectionStat(pillar).setOldestChecksumTimestamp(metric.getOldestChecksumTimestamp());
+                sc.getPillarCollectionStat(pillar).setFileCount(metric.pillarFileCount());
+                sc.getPillarCollectionStat(pillar).setDataSize(metric.pillarCollectionSize());
+                sc.getPillarCollectionStat(pillar).setOldestChecksumTimestamp(metric.oldestChecksumTimestamp());
             }
         }
         sc.getCollectionStat().setFileCount(store.getNumberOfFilesInCollection(collectionID));
         sc.getCollectionStat().setDataSize(store.getCollectionFileSize(collectionID));
-        sc.getCollectionStat().setLatestFileTime(store.getDateForNewestFileEntryForCollection(collectionID));
+        sc.getCollectionStat().setLatestFileTime(store.getDateForNewestFileEntryForCollectionInstant(collectionID));
 
         store.createStatistics(collectionID, sc);
     }

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/GetFileStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/GetFileStep.java
@@ -58,8 +58,8 @@ public class GetFileStep extends AbstractWorkFlowStep {
 
     @Override
     public void performStep() {
-        IntegrityEventCompleteAwaiter eventHandler = new IntegrityEventCompleteAwaiter(context.getSettings());
-        context.getCollector().getFile(collectionId, fileId, uploadUrl, eventHandler, "IntegrityService: "
+        IntegrityEventCompleteAwaiter eventHandler = new IntegrityEventCompleteAwaiter(context.settings());
+        context.collector().getFile(collectionId, fileId, uploadUrl, eventHandler, "IntegrityService: "
                 + getName());
 
         OperationEvent event = eventHandler.getFinish();

--- a/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/PutFileStep.java
+++ b/bitrepository-integrity-service/src/main/java/org/bitrepository/integrityservice/workflow/step/PutFileStep.java
@@ -69,11 +69,11 @@ public class PutFileStep extends AbstractWorkFlowStep {
 
     @Override
     public void performStep() {
-        IntegrityEventCompleteAwaiter eventHandler = new IntegrityEventCompleteAwaiter(context.getSettings());
+        IntegrityEventCompleteAwaiter eventHandler = new IntegrityEventCompleteAwaiter(context.settings());
 
         ChecksumDataForFileTYPE checksumValidationData = new ChecksumDataForFileTYPE();
         checksumValidationData.setCalculationTimestamp(CalendarUtils.getNow());
-        checksumValidationData.setChecksumSpec(ChecksumUtils.getDefault(context.getSettings()));
+        checksumValidationData.setChecksumSpec(ChecksumUtils.getDefault(context.settings()));
         try {
             checksumValidationData.setChecksumValue(Base16Utils.encodeBase16(checksum));
         } catch (DecoderException e) {
@@ -81,7 +81,7 @@ public class PutFileStep extends AbstractWorkFlowStep {
         }
 
 
-        context.getCollector()
+        context.collector()
                 .putFile(collectionId, fileId, uploadUrl, checksumValidationData, eventHandler, "IntegrityService: " + getName());
 
         OperationEvent event = eventHandler.getFinish();

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDAOTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/IntegrityDAOTest.java
@@ -634,8 +634,8 @@ class IntegrityDAOTest extends IntegrityDatabaseTestCase {
                 "The collection should have two files, the first pillar two, the second one");
         Assertions.assertEquals(2, (long) cache.getNumberOfFilesInCollection(TEST_COLLECTIONID));
         Map<String, PillarCollectionMetric> metrics = cache.getPillarCollectionMetrics(TEST_COLLECTIONID);
-        Assertions.assertEquals(2, metrics.get(TEST_PILLAR_1).getPillarFileCount());
-        Assertions.assertEquals(1, metrics.get(TEST_PILLAR_2).getPillarFileCount());
+        Assertions.assertEquals(2, metrics.get(TEST_PILLAR_1).pillarFileCount());
+        Assertions.assertEquals(1, metrics.get(TEST_PILLAR_2).pillarFileCount());
 
         addStep("Extract missing files", "one file should be missing");
         List<String> missingFiles
@@ -760,10 +760,10 @@ class IntegrityDAOTest extends IntegrityDatabaseTestCase {
         Map<String, PillarCollectionMetric> metrics = cache.getPillarCollectionMetrics(TEST_COLLECTIONID);
         addStep("Check the reported size of the first pillar in the collection",
                 "The reported size matches the precalculated");
-        Assertions.assertEquals(pillar1Size, metrics.get(TEST_PILLAR_1).getPillarCollectionSize());
+        Assertions.assertEquals(pillar1Size, metrics.get(TEST_PILLAR_1).pillarCollectionSize());
         addStep("Check the reported size of the second pillar in the collection",
                 "The reported size matches the precalculated");
-        Assertions.assertEquals(pillar2Size, metrics.get(TEST_PILLAR_2).getPillarCollectionSize());
+        Assertions.assertEquals(pillar2Size, metrics.get(TEST_PILLAR_2).pillarCollectionSize());
         addStep("Check the reported size of the whole collection",
                 "The reported size matches the precalculated");
         Assertions.assertEquals(collectionSize, cache.getCollectionSize(TEST_COLLECTIONID));

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/PillarCollectionMetricTest.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/cache/PillarCollectionMetricTest.java
@@ -1,0 +1,38 @@
+package org.bitrepository.integrityservice.cache;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("regressiontest")
+class PillarCollectionMetricTest {
+
+    @Test
+    void canonicalConstructorStoresValues() {
+        Instant ts = Instant.ofEpochMilli(1000);
+        PillarCollectionMetric m = new PillarCollectionMetric(10L, 5L, ts);
+        assertEquals(10L, m.pillarCollectionSize());
+        assertEquals(5L, m.pillarFileCount());
+        assertEquals(ts, m.oldestChecksumTimestamp());
+    }
+
+    @Test
+    void nullableConstructorCoercesNullSizeToZero() {
+        PillarCollectionMetric m = new PillarCollectionMetric((Long) null, (Long) null, null);
+        assertEquals(0L, m.pillarCollectionSize());
+        assertEquals(0L, m.pillarFileCount());
+        assertNull(m.oldestChecksumTimestamp());
+    }
+
+    @Test
+    void equalityIsComponentBased() {
+        Instant ts = Instant.ofEpochMilli(1000);
+        PillarCollectionMetric a = new PillarCollectionMetric(10L, 5L, ts);
+        PillarCollectionMetric b = new PillarCollectionMetric(10L, 5L, ts);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/integrationtest/MissingChecksumTests.java
+++ b/bitrepository-integrity-service/src/test/java/org/bitrepository/integrityservice/integrationtest/MissingChecksumTests.java
@@ -176,8 +176,8 @@ class MissingChecksumTests {
 
         addStep("Check whether checksum is missing", "Should be missing at pillar two only.");
         Map<String, PillarCollectionMetric> metrics = model.getPillarCollectionMetrics(TEST_COLLECTION);
-        Assertions.assertEquals(1, metrics.get(PILLAR_1).getPillarFileCount());
-        Assertions.assertEquals(1, metrics.get(PILLAR_2).getPillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_1).pillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_2).pillarFileCount());
 
         List<String> missingChecksumsPillar1
                 = getIssuesFromIterator(model.findFilesWithMissingChecksum(TEST_COLLECTION, PILLAR_1, testStart));
@@ -229,8 +229,8 @@ class MissingChecksumTests {
 
         addStep("Check whether checksum is missing", "Should be missing at pillar two only.");
         Map<String, PillarCollectionMetric> metrics = model.getPillarCollectionMetrics(TEST_COLLECTION);
-        Assertions.assertEquals(1, metrics.get(PILLAR_1).getPillarFileCount());
-        Assertions.assertEquals(1, metrics.get(PILLAR_2).getPillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_1).pillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_2).pillarFileCount());
 
         for (String pillar : Arrays.asList(PILLAR_1, PILLAR_2)) {
             List<String> missingChecksums
@@ -263,8 +263,8 @@ class MissingChecksumTests {
         addStep("Check whether checksum is missing",
                 "Should be missing at pillar one, and not on pillar two.");
         metrics = model.getPillarCollectionMetrics(TEST_COLLECTION);
-        Assertions.assertEquals(1, metrics.get(PILLAR_1).getPillarFileCount());
-        Assertions.assertEquals(1, metrics.get(PILLAR_2).getPillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_1).pillarFileCount());
+        Assertions.assertEquals(1, metrics.get(PILLAR_2).pillarFileCount());
 
         List<String> missingChecksumsPillar1
                 = getIssuesFromIterator(model.findFilesWithMissingChecksum(TEST_COLLECTION, PILLAR_1, secondUpdate));

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/DeleteFileRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/DeleteFileRequestHandler.java
@@ -136,7 +136,7 @@ public class DeleteFileRequestHandler extends PerformRequestHandler<DeleteFileRe
         deleteTheFile(request);
         getAuditManager().addAuditEvent(request.getCollectionID(), request.getFileID(), request.getFrom(),
                 "Deleting the file.", request.getAuditTrailInformation(), FileAction.DELETE_FILE,
-                request.getCorrelationID(), requestContext.getCertificateFingerprint());
+                request.getCorrelationID(), requestContext.certificateFingerprint());
         sendFinalResponse(request, resultingChecksum);
     }
 

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetFileRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetFileRequestHandler.java
@@ -106,7 +106,7 @@ public class GetFileRequestHandler extends PerformRequestHandler<GetFileRequest>
         uploadToClient(request);
         getAuditManager().addAuditEvent(request.getCollectionID(), request.getFileID(), request.getFrom(),
                 "Failed identifying pillar.", request.getAuditTrailInformation(), FileAction.GET_FILE,
-                request.getCorrelationID(), requestContext.getCertificateFingerprint());
+                request.getCorrelationID(), requestContext.certificateFingerprint());
         sendFinalResponse(request);
     }
 

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/PutFileRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/PutFileRequestHandler.java
@@ -104,7 +104,7 @@ public class PutFileRequestHandler extends PerformRequestHandler<PutFileRequest>
             retrieveFile(request);
             getAuditManager().addAuditEvent(request.getCollectionID(), request.getFileID(), request.getFrom(),
                     "Add file to archive.", request.getAuditTrailInformation(), FileAction.PUT_FILE,
-                    request.getCorrelationID(), requestContext.getCertificateFingerprint());
+                    request.getCorrelationID(), requestContext.certificateFingerprint());
             sendFinalResponse(request);
         } finally {
             getPillarModel().ensureFileNotInTmpDir(request.getFileID(), request.getCollectionID());

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/ReplaceFileRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/ReplaceFileRequestHandler.java
@@ -122,7 +122,7 @@ public class ReplaceFileRequestHandler extends PerformRequestHandler<ReplaceFile
             replaceFile(request);
             getAuditManager().addAuditEvent(request.getCollectionID(), request.getFileID(), request.getFrom(),
                     "Replacing the file.", request.getAuditTrailInformation(), FileAction.REPLACE_FILE,
-                    request.getCorrelationID(), requestContext.getCertificateFingerprint());
+                    request.getCorrelationID(), requestContext.certificateFingerprint());
 
             ChecksumDataForFileTYPE requestedNewChecksum = calculateChecksumOnNewFile(request);
             sendFinalResponse(request, requestedOldChecksum, requestedNewChecksum);

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/StorageModel.java
@@ -168,10 +168,10 @@ public abstract class StorageModel {
             throws RequestHandlerException {
         ChecksumEntry entry = getChecksumEntryForFile(fileID, collectionID, csType);
         ChecksumDataForFileTYPE res = new ChecksumDataForFileTYPE();
-        res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.getCalculationInstant()));
+        res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.calculationInstant()));
         res.setChecksumSpec(csType);
         try {
-            res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+            res.setChecksumValue(Base16Utils.encodeBase16(entry.checksum()));
         } catch (DecoderException e) {
             throw new IllegalArgumentException("Could not encode checksum.", e);
         }
@@ -238,8 +238,8 @@ public abstract class StorageModel {
         ExtractedChecksumResultSet res = new ExtractedChecksumResultSet();
         ChecksumEntry entry = getChecksumEntryForFile(fileID, collectionID, csSpec);
 
-        boolean lowerBound = minTimestamp == null || !minTimestamp.isAfter(entry.getCalculationInstant());
-        boolean upperBound = maxTimestamp == null || !maxTimestamp.isBefore(entry.getCalculationInstant());
+        boolean lowerBound = minTimestamp == null || !minTimestamp.isAfter(entry.calculationInstant());
+        boolean upperBound = maxTimestamp == null || !maxTimestamp.isBefore(entry.calculationInstant());
         if (lowerBound && upperBound) {
             res.insertChecksumEntry(entry);
         }

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ChecksumEntry.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ChecksumEntry.java
@@ -29,22 +29,10 @@ import java.util.Date;
 /**
  * Container for the information about the checksum of a file.
  */
-public class ChecksumEntry {
-    protected final String fileID;
-    protected final String checksum;
-    protected final Instant calculationDate;
+public record ChecksumEntry(String fileID, String checksum, Instant calculationInstant) {
 
-    /**
-     * @param fileID          The id of the file.
-     * @param checksum        The checksum of the file.
-     * @param calculationDate The calculation date for the checksum of the file.
-     */
-    public ChecksumEntry(String fileID, String checksum, Instant calculationDate) {
+    public ChecksumEntry {
         ArgumentValidator.checkNotNullOrEmpty(fileID, "String fileID");
-
-        this.fileID = fileID;
-        this.checksum = checksum;
-        this.calculationDate = calculationDate;
     }
 
     /**
@@ -58,30 +46,23 @@ public class ChecksumEntry {
         this(fileID, checksum, calculationDate != null ? calculationDate.toInstant() : null);
     }
 
-    /**
-     * @return The id of the file.
-     */
     public String getFileId() {
         return fileID;
     }
 
-    /**
-     * @return The checksum of the file.
-     */
     public String getChecksum() {
         return checksum;
     }
 
+    public Instant getCalculationInstant() {
+        return calculationInstant;
+    }
+
     /**
-     * @return The calculation date for the checksum of the file.
      * @deprecated Use {@link #getCalculationInstant()} instead
      */
     @Deprecated(forRemoval = true)
     public Date getCalculationDate() {
-        return calculationDate != null ? Date.from(calculationDate) : null;
-    }
-
-    public Instant getCalculationInstant() {
-        return calculationDate;
+        return calculationInstant != null ? Date.from(calculationInstant) : null;
     }
 }

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ChecksumEntry.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ChecksumEntry.java
@@ -28,6 +28,10 @@ import java.util.Date;
 
 /**
  * Container for the information about the checksum of a file.
+ *
+ * @param fileID             The id of the file.
+ * @param checksum           The checksum of the file.
+ * @param calculationInstant The calculation date for the checksum of the file.
  */
 public record ChecksumEntry(String fileID, String checksum, Instant calculationInstant) {
 
@@ -36,9 +40,6 @@ public record ChecksumEntry(String fileID, String checksum, Instant calculationI
     }
 
     /**
-     * @param fileID          The id of the file.
-     * @param checksum        The checksum of the file.
-     * @param calculationDate The calculation date for the checksum of the file.
      * @deprecated Use {@link #ChecksumEntry(String, String, Instant)} instead
      */
     @Deprecated(forRemoval = true)
@@ -46,14 +47,26 @@ public record ChecksumEntry(String fileID, String checksum, Instant calculationI
         this(fileID, checksum, calculationDate != null ? calculationDate.toInstant() : null);
     }
 
+    /**
+     * @deprecated Use {@link #fileID()} instead
+     */
+    @Deprecated(forRemoval = true)
     public String getFileId() {
         return fileID;
     }
 
+    /**
+     * @deprecated Use {@link #checksum()} instead
+     */
+    @Deprecated(forRemoval = true)
     public String getChecksum() {
         return checksum;
     }
 
+    /**
+     * @deprecated Use {@link #calculationInstant()} instead
+     */
+    @Deprecated(forRemoval = true)
     public Instant getCalculationInstant() {
         return calculationInstant;
     }

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/store/checksumdatabase/ExtractedChecksumResultSet.java
@@ -60,14 +60,14 @@ public class ExtractedChecksumResultSet {
      */
     public void insertChecksumEntry(ChecksumEntry entry) {
         ChecksumDataForChecksumSpecTYPE res = new ChecksumDataForChecksumSpecTYPE();
-        res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.getCalculationDate()));
+        res.setCalculationTimestamp(CalendarUtils.getXmlGregorianCalendar(entry.calculationInstant()));
         try {
-            res.setChecksumValue(Base16Utils.encodeBase16(entry.getChecksum()));
+            res.setChecksumValue(Base16Utils.encodeBase16(entry.checksum()));
         } catch (DecoderException e) {
             throw new IllegalArgumentException("Could not encode checksum.", e);
         }
 
-        res.setFileID(entry.getFileId());
+        res.setFileID(entry.fileID());
         entries.add(res);
     }
 

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
@@ -47,4 +47,31 @@ class ChecksumEntryTest {
         Assertions.assertEquals(CE_CHECKSUM, ce.getChecksum());
         Assertions.assertEquals(CE_DATE, ce.getCalculationInstant());
     }
+
+    @Test
+    @Tag("regressiontest")
+    @Tag("pillartest")
+    void compactConstructorRejectsNullFileID() {
+        addDescription("The compact constructor must reject a null fileID");
+        Assertions.assertThrows(Exception.class, () -> new ChecksumEntry(null, CE_CHECKSUM, CE_DATE));
+    }
+
+    @Test
+    @Tag("regressiontest")
+    @Tag("pillartest")
+    void compactConstructorRejectsEmptyFileID() {
+        addDescription("The compact constructor must reject an empty fileID");
+        Assertions.assertThrows(Exception.class, () -> new ChecksumEntry("", CE_CHECKSUM, CE_DATE));
+    }
+
+    @Test
+    @Tag("regressiontest")
+    @Tag("pillartest")
+    void equalityIsComponentBased() {
+        addDescription("Two ChecksumEntries with identical components must be equal");
+        ChecksumEntry a = new ChecksumEntry(CE_FILE, CE_CHECKSUM, CE_DATE);
+        ChecksumEntry b = new ChecksumEntry(CE_FILE, CE_CHECKSUM, CE_DATE);
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+    }
 }

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
@@ -53,7 +53,7 @@ class ChecksumEntryTest {
     @Tag("pillartest")
     void compactConstructorRejectsNullFileID() {
         addDescription("The compact constructor must reject a null fileID");
-        Assertions.assertThrows(Exception.class, () -> new ChecksumEntry(null, CE_CHECKSUM, CE_DATE));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ChecksumEntry(null, CE_CHECKSUM, CE_DATE));
     }
 
     @Test
@@ -61,7 +61,7 @@ class ChecksumEntryTest {
     @Tag("pillartest")
     void compactConstructorRejectsEmptyFileID() {
         addDescription("The compact constructor must reject an empty fileID");
-        Assertions.assertThrows(Exception.class, () -> new ChecksumEntry("", CE_CHECKSUM, CE_DATE));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ChecksumEntry("", CE_CHECKSUM, CE_DATE));
     }
 
     @Test

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
@@ -43,9 +43,9 @@ class ChecksumEntryTest {
         addDescription("Test the ChecksumEntry");
         addStep("Create a ChecksumEntry", "The data should be extractable again.");
         ChecksumEntry ce = new ChecksumEntry(CE_FILE, CE_CHECKSUM, CE_DATE);
-        Assertions.assertEquals(CE_FILE, ce.getFileId());
-        Assertions.assertEquals(CE_CHECKSUM, ce.getChecksum());
-        Assertions.assertEquals(CE_DATE, ce.getCalculationInstant());
+        Assertions.assertEquals(CE_FILE, ce.fileID());
+        Assertions.assertEquals(CE_CHECKSUM, ce.checksum());
+        Assertions.assertEquals(CE_DATE, ce.calculationInstant());
     }
 
     @Test

--- a/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
+++ b/bitrepository-reference-pillar/src/test/java/org/bitrepository/pillar/store/checksumcache/ChecksumEntryTest.java
@@ -63,15 +63,4 @@ class ChecksumEntryTest {
         addDescription("The compact constructor must reject an empty fileID");
         Assertions.assertThrows(IllegalArgumentException.class, () -> new ChecksumEntry("", CE_CHECKSUM, CE_DATE));
     }
-
-    @Test
-    @Tag("regressiontest")
-    @Tag("pillartest")
-    void equalityIsComponentBased() {
-        addDescription("Two ChecksumEntries with identical components must be equal");
-        ChecksumEntry a = new ChecksumEntry(CE_FILE, CE_CHECKSUM, CE_DATE);
-        ChecksumEntry b = new ChecksumEntry(CE_FILE, CE_CHECKSUM, CE_DATE);
-        Assertions.assertEquals(a, b);
-        Assertions.assertEquals(a.hashCode(), b.hashCode());
-    }
 }

--- a/bitrepository-service/src/main/java/org/bitrepository/service/workflow/JobID.java
+++ b/bitrepository-service/src/main/java/org/bitrepository/service/workflow/JobID.java
@@ -24,53 +24,7 @@ package org.bitrepository.service.workflow;
 /**
  * Class to identify a workflow instance, based on the collection it belongs to and the workflow name/type.
  */
-public class JobID {
-    private final String collectionID;
-    private final String workflowName;
-
-    public JobID(String workflowName, String collectionID) {
-        this.collectionID = collectionID;
-        this.workflowName = workflowName;
-    }
-
-    public String getWorkflowName() {
-        return workflowName;
-    }
-
-    public String getCollectionID() {
-        return collectionID;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result
-                + ((collectionID == null) ? 0 : collectionID.hashCode());
-        result = prime * result
-                + ((workflowName == null) ? 0 : workflowName.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        JobID other = (JobID) obj;
-        if (collectionID == null) {
-            if (other.collectionID != null)
-                return false;
-        } else if (!collectionID.equals(other.collectionID))
-            return false;
-        if (workflowName == null) {
-            return other.workflowName == null;
-        } else return workflowName.equals(other.workflowName);
-    }
-
+public record JobID(String workflowName, String collectionID) {
     @Override
     public String toString() {
         return workflowName + "-" + collectionID;

--- a/bitrepository-service/src/main/java/org/bitrepository/service/workflow/JobID.java
+++ b/bitrepository-service/src/main/java/org/bitrepository/service/workflow/JobID.java
@@ -29,4 +29,20 @@ public record JobID(String workflowName, String collectionID) {
     public String toString() {
         return workflowName + "-" + collectionID;
     }
+
+    /**
+     * @deprecated Use {@link #workflowName()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    /**
+     * @deprecated Use {@link #collectionID()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public String getCollectionID() {
+        return collectionID;
+    }
 }

--- a/bitrepository-service/src/test/java/org/bitrepository/service/workflow/JobIDTest.java
+++ b/bitrepository-service/src/test/java/org/bitrepository/service/workflow/JobIDTest.java
@@ -1,0 +1,47 @@
+package org.bitrepository.service.workflow;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("regressiontest")
+class JobIDTest {
+
+    @Test
+    void accessorsReturnConstructorValues() {
+        JobID id = new JobID("MyWorkflow", "col1");
+        assertEquals("MyWorkflow", id.workflowName());
+        assertEquals("col1", id.collectionID());
+    }
+
+    @Test
+    void equalityIsComponentBased() {
+        JobID a = new JobID("wf", "col");
+        JobID b = new JobID("wf", "col");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void inequalityOnDifferentComponents() {
+        JobID base = new JobID("wf", "col");
+        assertNotEquals(base, new JobID("other", "col"));
+        assertNotEquals(base, new JobID("wf", "other"));
+    }
+
+    @Test
+    void toStringUsesCustomFormat() {
+        assertEquals("wf-col", new JobID("wf", "col").toString());
+    }
+
+    @Test
+    void nullComponentsAreAllowed() {
+        // Records do not reject nulls unless the compact constructor does so;
+        // JobID has no validation, so nulls must be accepted.
+        JobID id = new JobID(null, null);
+        assertNull(id.workflowName());
+        assertNull(id.collectionID());
+        assertEquals(new JobID(null, null), id);
+    }
+}


### PR DESCRIPTION
Converted 10 immutable classes to Java
Deleted equals(), hashCode(), and toString() implementations where Java's auto-generated record versions are equivalent
Updated all call sites to use record accessor names
Added dedicated unit tests for record-specific behaviour: compact constructor validation, non-canonical constructor null-coalescing, custom toString format, and component-based equality