### PR TITLE
Update maven dependencies

### DIFF
--- a/bitrepository-alarm-service/pom.xml
+++ b/bitrepository-alarm-service/pom.xml
@@ -82,8 +82,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-audit-trail-service/pom.xml
+++ b/bitrepository-audit-trail-service/pom.xml
@@ -81,8 +81,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-client/pom.xml
+++ b/bitrepository-client/pom.xml
@@ -31,8 +31,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-core/pom.xml
+++ b/bitrepository-core/pom.xml
@@ -57,8 +57,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-client</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-jakarta-client</artifactId>
+      <version>${artemis.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -67,8 +67,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
@@ -34,8 +34,9 @@ import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.util.ByteArrayInputStream;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+
+import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorymessages.Message;
 import org.bitrepository.bitrepositorymessages.MessageRequest;
 import org.bitrepository.common.DefaultThreadFactory;
@@ -85,16 +86,16 @@ public class ActiveMQMessageBus implements MessageBus {
     /**
      * The key for storing the message type in a string property in the message headers.
      */
-    public static final String MESSAGE_TYPE_KEY = "org.bitrepository.messages.type";
+    public static final String MESSAGE_TYPE_KEY = "org_bitrepository_messages_type";
     /**
      * The key for storing the BitRepositoryCollectionID in a string property in the message headers.
      */
-    public static final String COLLECTION_ID_KEY = "org.bitrepository.messages.collectionid";
+    public static final String COLLECTION_ID_KEY = "org_bitrepository_messages_collectionid";
     /**
      * The key for storing the message type in a string property in the message headers.
      */
-    public static final String MESSAGE_SIGNATURE_KEY = "org.bitrepository.messages.signature";
-    public static final String MESSAGE_TO_KEY = "org.bitrepository.messages.to";
+    public static final String MESSAGE_SIGNATURE_KEY = "org_bitrepository_messages_signature";
+    public static final String MESSAGE_TO_KEY = "org_bitrepository_messages_to";
     /**
      * Default transacted.
      */

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/FileUtilsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/FileUtilsTest.java
@@ -21,7 +21,7 @@
  */
 package org.bitrepository.common.utils;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/bitrepository-core/src/test/java/org/bitrepository/common/utils/StreamUtilsTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/common/utils/StreamUtilsTest.java
@@ -21,7 +21,7 @@
  */
 package org.bitrepository.common.utils;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/MessageCreationTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/MessageCreationTest.java
@@ -24,7 +24,7 @@
  */
 package org.bitrepository.protocol;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
 import org.bitrepository.bitrepositorymessages.AlarmMessage;
 import org.bitrepository.bitrepositorymessages.GetChecksumsFinalResponse;

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/LocalActiveMQBroker.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/LocalActiveMQBroker.java
@@ -1,62 +1,64 @@
 /*
  * #%L
  * Bitrepository Protocol
- * 
+ *
  * $Id$
  * $HeadURL$
  * %%
  * Copyright (C) 2010 - 2011 The State and University Library, The Royal Library and The State Archives, Denmark
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 2.1 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.bitrepository.protocol.bus;
 
-import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LocalActiveMQBroker {
     private final Logger log = LoggerFactory.getLogger(getClass());
-    
-    private final BrokerService broker;
-    
+
+    private final EmbeddedActiveMQ server;
+
     public LocalActiveMQBroker(MessageBusConfiguration configuration) {
-        broker = new BrokerService();
-        broker.setPersistent(false);
-        broker.setDataDirectory("target/activemq-data");
         try {
-            broker.addConnector(configuration.getURL());
+            Configuration config = new ConfigurationImpl()
+                    .setPersistenceEnabled(false)
+                    .setSecurityEnabled(false)
+                    .addAcceptorConfiguration("tcp", configuration.getURL());
+            server = new EmbeddedActiveMQ();
+            server.setConfiguration(config);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
-        log.info("Created embedded broker {}", broker);
+        log.info("Created embedded Artemis broker on {}", configuration.getURL());
     }
-    
+
     public void start() {
         try {
-            broker.start();
-            broker.waitUntilStarted();
+            server.start();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
-    
+
     public void stop() throws Exception {
-        broker.stop();
-        broker.waitUntilStopped();
+        server.stop();
     }
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/MessageBusConfigurationFactory.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/MessageBusConfigurationFactory.java
@@ -35,7 +35,7 @@ public class MessageBusConfigurationFactory {
     
     public static MessageBusConfiguration createDefaultConfiguration() {
         MessageBusConfiguration config = new MessageBusConfiguration();
-        config.setURL("failover://tcp://sandkasse-01.kb.dk:61616");
+        config.setURL("tcp://sandkasse-01.kb.dk:61616?reconnectAttempts=-1");
         return config;
     }
     

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -30,7 +30,7 @@ import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
-import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.bitrepository.common.JaxbHelper;
 import org.bitrepository.protocol.CoordinationLayerException;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/fileexchange/LocalFileExchangeTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/fileexchange/LocalFileExchangeTest.java
@@ -4,7 +4,7 @@ import org.apache.commons.io.IOUtils;
 import org.bitrepository.protocol.FileExchange;
 import org.bitrepository.protocol.LocalFileExchange;
 import org.bitrepository.settings.referencesettings.FileExchangeSettings;
-import org.fusesource.hawtbuf.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/message/ExampleMessageFactory.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/message/ExampleMessageFactory.java
@@ -24,7 +24,7 @@
  */
 package org.bitrepository.protocol.message;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.apache.commons.io.IOUtils;
 import org.bitrepository.common.JaxbHelper;
 

--- a/bitrepository-integrity-service/pom.xml
+++ b/bitrepository-integrity-service/pom.xml
@@ -86,8 +86,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-monitoring-service/pom.xml
+++ b/bitrepository-monitoring-service/pom.xml
@@ -80,8 +80,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
+      <artifactId>artemis-server</artifactId>
+      <version>${artemis.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bitrepository-reference-pillar/pom.xml
+++ b/bitrepository-reference-pillar/pom.xml
@@ -52,8 +52,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
+            <artifactId>artemis-server</artifactId>
+            <version>${artemis.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetChecksumsRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetChecksumsRequestHandler.java
@@ -24,7 +24,7 @@
  */
 package org.bitrepository.pillar.messagehandler;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorydata.GetChecksumsResults;
 import org.bitrepository.bitrepositoryelements.ChecksumDataForChecksumSpecTYPE;
 import org.bitrepository.bitrepositoryelements.ResponseCode;

--- a/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetFileIDsRequestHandler.java
+++ b/bitrepository-reference-pillar/src/main/java/org/bitrepository/pillar/messagehandler/GetFileIDsRequestHandler.java
@@ -25,7 +25,7 @@
  */
 package org.bitrepository.pillar.messagehandler;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorydata.GetFileIDsResults;
 import org.bitrepository.bitrepositoryelements.FileIDsData;
 import org.bitrepository.bitrepositoryelements.ResponseCode;

--- a/bitrepository-service/src/main/java/org/bitrepository/service/contributor/handler/GetAuditTrailsRequestHandler.java
+++ b/bitrepository-service/src/main/java/org/bitrepository/service/contributor/handler/GetAuditTrailsRequestHandler.java
@@ -21,7 +21,7 @@
  */
 package org.bitrepository.service.contributor.handler;
 
-import org.apache.activemq.util.ByteArrayInputStream;
+import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorydata.GetAuditTrailsResults;
 import org.bitrepository.bitrepositoryelements.ResponseCode;
 import org.bitrepository.bitrepositoryelements.ResponseInfo;

--- a/pom.xml
+++ b/pom.xml
@@ -588,6 +588,7 @@
         <repository.settings.version>14</repository.settings.version>
         <derby.version>10.17.1.0</derby.version>
         <activemq.version>6.2.4</activemq.version>
+        <artemis.version>2.54.0</artemis.version>
         <cxf.version>4.2.0</cxf.version>
         <jackson.version>2.21.2</jackson.version>
         <jakarta.ws.rs.version>2.1.6</jakarta.ws.rs.version>


### PR DESCRIPTION
Replaced activemq-client (Classic 6.x) with artemis-jakarta-client:2.54.0 as the production JMS client in bitrepository-core                                                                                                                                            
Replaced activemq-broker (Classic embedded broker used in tests) with artemis-server:2.54.0 in all 7 modules                                                                                                                                                          Added artemis.version=2.54.0 property to root pom.xml                                                                               Rewrote LocalActiveMQBroker to use Artemis EmbeddedActiveMQ instead of Classic BrokerService           Updated ActiveMQMessageBus and RawMessagebus to use org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory                                                                                                                         Replaced org.apache.activemq.util.ByteArrayInputStream and org.fusesource.hawtbuf.ByteArrayInputStream (both Classic-transitive) with java.io.ByteArrayInputStream across 9 files                  Updated MessageBusConfigurationFactory to use Artemis reconnect URL format (?reconnectAttempts=-1) instead of Classic failover transport (failover://tcp://)                                           

Artemis enforces the JMS 2.0 specification strictly — message property names must be valid Java identifiers (no dots allowed). The four internal message property keys (org.bitrepository.messages.type etc.) used dots as separators, which Classic silently accepted but Artemis rejects at runtime. These have been renamed to use underscores (org_bitrepositor Jump to bottom (ctrl+End) ↓ eads and writes go through the public constants in ActiveMQMessageBus, no external protocol is affected.               
 