### PR TITLE
BITMAG-1275-replacement-of-activemq-connection-factory

### DIFF
--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
@@ -172,7 +172,7 @@ public class ActiveMQMessageBus implements MessageBus {
         clientID = settings.getComponentID();
         String schemaLocation = "BitRepositoryMessages.xsd";
         jaxbHelper = new JaxbHelper("xsd/", schemaLocation);
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(configuration.getURL());
+        ActiveMQConnectionFactory connectionFactory = ArtemisConnectionFactoryProvider.create(configuration);
         registerCustomMessageLoggers();
         try {
             connection = connectionFactory.createConnection();

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProvider.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProvider.java
@@ -30,16 +30,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Creates and configures {@link ActiveMQConnectionFactory} instances for Artemis.
+ * Creates and configures ActiveMQConnectionFactory instances for Artemis.
  *
  * <p>The broker URL is resolved in priority order:
  * <ol>
- *   <li>Environment variable {@value #BROKER_URL_ENV}</li>
- *   <li>URL from {@link MessageBusConfiguration}</li>
+ *   <li>Environment variable #BROKER_URL_ENV</li>
+ *   <li>URL from MessageBusConfiguration</li>
  * </ol>
- *
- * <p>If the resolved URL does not already contain {@code reconnectAttempts},
- * {@code ?reconnectAttempts=-1} is appended to enable indefinite reconnect.
  */
 public final class ArtemisConnectionFactoryProvider {
     private static final Logger log = LoggerFactory.getLogger(ArtemisConnectionFactoryProvider.class);
@@ -61,10 +58,24 @@ public final class ArtemisConnectionFactoryProvider {
     /**
      * Resolves the broker URL from environment variable or configuration,
      * and ensures {@code reconnectAttempts=-1} is present.
+     *
+     * @throws IllegalArgumentException if {@link #BROKER_URL_ENV} is not set and {@code config}
+     *         is {@code null} or has no URL
      */
     static String resolveUrl(MessageBusConfiguration config) {
         String envUrl = System.getenv(BROKER_URL_ENV);
-        String base = (envUrl != null && !envUrl.isBlank()) ? envUrl : config.getURL();
+        if (envUrl != null && !envUrl.isBlank()) {
+            return appendReconnectAttempts(envUrl);
+        }
+        if (config == null || config.getURL() == null || config.getURL().isBlank()) {
+            throw new IllegalArgumentException(
+                    "MessageBusConfiguration with a non-blank URL is required when " + BROKER_URL_ENV
+                            + " is not set");
+        }
+        return appendReconnectAttempts(config.getURL());
+    }
+
+    private static String appendReconnectAttempts(String base) {
         if (!base.contains("reconnectAttempts")) {
             return base + (base.contains("?") ? "&" : "?") + "reconnectAttempts=-1";
         }

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProvider.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProvider.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * Bitmagasin integrationstest
+ *
+ * $Id$
+ * $HeadURL$
+ * %%
+ * Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.bitrepository.protocol.activemq;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates and configures {@link ActiveMQConnectionFactory} instances for Artemis.
+ *
+ * <p>The broker URL is resolved in priority order:
+ * <ol>
+ *   <li>Environment variable {@value #BROKER_URL_ENV}</li>
+ *   <li>URL from {@link MessageBusConfiguration}</li>
+ * </ol>
+ *
+ * <p>If the resolved URL does not already contain {@code reconnectAttempts},
+ * {@code ?reconnectAttempts=-1} is appended to enable indefinite reconnect.
+ */
+public final class ArtemisConnectionFactoryProvider {
+    private static final Logger log = LoggerFactory.getLogger(ArtemisConnectionFactoryProvider.class);
+
+    /** Environment variable that overrides the broker URL from configuration. */
+    public static final String BROKER_URL_ENV = "ARTEMIS_BROKER_URL";
+
+    private ArtemisConnectionFactoryProvider() {}
+
+    /**
+     * Creates a new {@link ActiveMQConnectionFactory} using the resolved broker URL.
+     */
+    public static ActiveMQConnectionFactory create(MessageBusConfiguration config) {
+        String url = resolveUrl(config);
+        log.info("Creating Artemis connection factory with URL: {}", url);
+        return new ActiveMQConnectionFactory(url);
+    }
+
+    /**
+     * Resolves the broker URL from environment variable or configuration,
+     * and ensures {@code reconnectAttempts=-1} is present.
+     */
+    static String resolveUrl(MessageBusConfiguration config) {
+        String envUrl = System.getenv(BROKER_URL_ENV);
+        String base = (envUrl != null && !envUrl.isBlank()) ? envUrl : config.getURL();
+        if (!base.contains("reconnectAttempts")) {
+            return base + (base.contains("?") ? "&" : "?") + "reconnectAttempts=-1";
+        }
+        return base;
+    }
+}

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProviderTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProviderTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("regressiontest")
@@ -75,5 +76,17 @@ class ArtemisConnectionFactoryProviderTest {
     @Test
     void createReturnsNonNullFactory() {
         assertNotNull(ArtemisConnectionFactoryProvider.create(configWithUrl("tcp://localhost:61616")));
+    }
+
+    @Test
+    void resolveUrlThrowsWhenConfigIsNullAndEnvVarAbsent() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ArtemisConnectionFactoryProvider.resolveUrl(null));
+    }
+
+    @Test
+    void resolveUrlThrowsWhenConfigUrlIsBlankAndEnvVarAbsent() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ArtemisConnectionFactoryProvider.resolveUrl(configWithUrl("  ")));
     }
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProviderTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/activemq/ArtemisConnectionFactoryProviderTest.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * Bitmagasin integrationstest
+ *
+ * $Id$
+ * $HeadURL$
+ * %%
+ * Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.bitrepository.protocol.activemq;
+
+import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("regressiontest")
+class ArtemisConnectionFactoryProviderTest {
+
+    private static MessageBusConfiguration configWithUrl(String url) {
+        MessageBusConfiguration config = new MessageBusConfiguration();
+        config.setURL(url);
+        return config;
+    }
+
+    @Test
+    void resolveUrlAppendsReconnectAttemptsWhenAbsent() {
+        String result = ArtemisConnectionFactoryProvider.resolveUrl(
+                configWithUrl("tcp://localhost:61616"));
+        assertTrue(result.contains("reconnectAttempts=-1"),
+                "reconnectAttempts must be added when missing: " + result);
+    }
+
+    @Test
+    void resolveUrlDoesNotDuplicateReconnectAttempts() {
+        String url = "tcp://localhost:61616?reconnectAttempts=-1";
+        String result = ArtemisConnectionFactoryProvider.resolveUrl(configWithUrl(url));
+        assertTrue(result.indexOf("reconnectAttempts") == result.lastIndexOf("reconnectAttempts"),
+                "reconnectAttempts must appear exactly once: " + result);
+    }
+
+    @Test
+    void resolveUrlAppendsWithAmpersandWhenQueryParamAlreadyPresent() {
+        String result = ArtemisConnectionFactoryProvider.resolveUrl(
+                configWithUrl("tcp://localhost:61616?foo=bar"));
+        assertTrue(result.contains("&reconnectAttempts=-1"),
+                "Must use & separator when query already has params: " + result);
+    }
+
+    @Test
+    void resolveUrlUsesConfigUrlWhenEnvVarAbsent() {
+        String configUrl = "tcp://broker.example.com:61616";
+        String result = ArtemisConnectionFactoryProvider.resolveUrl(configWithUrl(configUrl));
+        assertTrue(result.startsWith(configUrl),
+                "URL must start with config URL when env var is absent: " + result);
+    }
+
+    @Test
+    void createReturnsNonNullFactory() {
+        assertNotNull(ArtemisConnectionFactoryProvider.create(configWithUrl("tcp://localhost:61616")));
+    }
+}

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -30,7 +30,7 @@ import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.bitrepository.protocol.activemq.ArtemisConnectionFactoryProvider;
 import org.bitrepository.common.JaxbHelper;
 import org.bitrepository.protocol.CoordinationLayerException;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;
@@ -56,7 +56,7 @@ public class RawMessagebus {
     public RawMessagebus(MessageBusConfiguration messageBusConfiguration, SecurityManager securityManager) {
         this.securityManager = securityManager;
 
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(messageBusConfiguration.getURL());
+        var connectionFactory = ArtemisConnectionFactoryProvider.create(messageBusConfiguration);
         try {
             connection = connectionFactory.createConnection();
             connection.setExceptionListener(new MessageBusExceptionListener());


### PR DESCRIPTION
  - Extracts ActiveMQConnectionFactory creation out of ActiveMQMessageBus/RawMessagebus into a new ArtemisConnectionFactoryProvider, so broker URL resolution lives in one place instead of being     
  inlined at each call site.                                                                                                                                                                          
  - Adds support for overriding the configured broker URL via the ARTEMIS_BROKER_URL environment variable, and ensures reconnectAttempts=-1 is always present on the resolved URL.                    
  - Validates the resolved MessageBusConfiguration: if ARTEMIS_BROKER_URL isn't set and the config is missing or has a blank URL, resolveUrl now throws IllegalArgumentException with a clear message 
  instead of failing later with a bare NullPointerException.   
  
