### PR TITLE
BITMAG-1276-refactor JMS resource

### DIFF
--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
@@ -187,7 +187,7 @@ public class ActiveMQMessageBus implements MessageBus {
 
             startListeningForMessages();
         } catch (JMSException e) {
-            closeQuietly(newConnection);
+            JmsConnectionUtils.closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
         log.debug("ActiveMQConnection initialized for '{}'", configuration);
@@ -212,20 +212,6 @@ public class ActiveMQMessageBus implements MessageBus {
             }
         });
         connectionStarter.start();
-    }
-
-    /**
-     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
-     * failed initialisation without masking the original error.
-     */
-    private void closeQuietly(Connection connection) {
-        if (connection != null) {
-            try {
-                connection.close();
-            } catch (JMSException e) {
-                log.warn("Failed to close connection after initialisation failure", e);
-            }
-        }
     }
 
     @Override

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
@@ -35,8 +35,6 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-
-import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorymessages.Message;
 import org.bitrepository.bitrepositorymessages.MessageRequest;
 import org.bitrepository.common.DefaultThreadFactory;
@@ -67,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -174,18 +173,21 @@ public class ActiveMQMessageBus implements MessageBus {
         jaxbHelper = new JaxbHelper("xsd/", schemaLocation);
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(configuration.getURL());
         registerCustomMessageLoggers();
+        Connection newConnection = null;
         try {
-            connection = connectionFactory.createConnection();
-            connection.setClientID(clientID);
-            connection.setExceptionListener(new MessageBusExceptionListener());
+            newConnection = connectionFactory.createConnection();
+            newConnection.setClientID(clientID);
+            newConnection.setExceptionListener(new MessageBusExceptionListener());
 
-            producerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            consumerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            producerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            consumerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
             producer = producerSession.createProducer(null);
             producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            connection = newConnection;
 
             startListeningForMessages();
         } catch (JMSException e) {
+            closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
         log.debug("ActiveMQConnection initialized for '{}'", configuration);
@@ -210,6 +212,20 @@ public class ActiveMQMessageBus implements MessageBus {
             }
         });
         connectionStarter.start();
+    }
+
+    /**
+     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
+     * failed initialisation without masking the original error.
+     */
+    private void closeQuietly(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (JMSException e) {
+                log.warn("Failed to close connection after initialisation failure", e);
+            }
+        }
     }
 
     @Override
@@ -251,12 +267,9 @@ public class ActiveMQMessageBus implements MessageBus {
     public void close() throws JMSException {
         receivedMessageHandler.close();
         log.info("Closing message bus: {}", configuration);
-        producerSession.close();
-        log.debug("Producer session closed.");
-        consumerSession.close();
-        log.debug("Consumer session closed.");
-        connection.close();
-        log.debug("Connection closed.");
+        try (connection; consumerSession; producerSession) {
+            log.debug("Closing producer session, consumer session and connection.");
+        }
     }
 
     @Override

--- a/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
+++ b/bitrepository-core/src/main/java/org/bitrepository/protocol/activemq/ActiveMQMessageBus.java
@@ -35,8 +35,6 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-
-import java.io.ByteArrayInputStream;
 import org.bitrepository.bitrepositorymessages.Message;
 import org.bitrepository.bitrepositorymessages.MessageRequest;
 import org.bitrepository.common.DefaultThreadFactory;
@@ -67,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -174,18 +173,21 @@ public class ActiveMQMessageBus implements MessageBus {
         jaxbHelper = new JaxbHelper("xsd/", schemaLocation);
         ActiveMQConnectionFactory connectionFactory = ArtemisConnectionFactoryProvider.create(configuration);
         registerCustomMessageLoggers();
+        Connection newConnection = null;
         try {
-            connection = connectionFactory.createConnection();
-            connection.setClientID(clientID);
-            connection.setExceptionListener(new MessageBusExceptionListener());
+            newConnection = connectionFactory.createConnection();
+            newConnection.setClientID(clientID);
+            newConnection.setExceptionListener(new MessageBusExceptionListener());
 
-            producerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            consumerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            producerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            consumerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
             producer = producerSession.createProducer(null);
             producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            connection = newConnection;
 
             startListeningForMessages();
         } catch (JMSException e) {
+            closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
         log.debug("ActiveMQConnection initialized for '{}'", configuration);
@@ -210,6 +212,20 @@ public class ActiveMQMessageBus implements MessageBus {
             }
         });
         connectionStarter.start();
+    }
+
+    /**
+     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
+     * failed initialisation without masking the original error.
+     */
+    private void closeQuietly(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (JMSException e) {
+                log.warn("Failed to close connection after initialisation failure", e);
+            }
+        }
     }
 
     @Override
@@ -251,12 +267,9 @@ public class ActiveMQMessageBus implements MessageBus {
     public void close() throws JMSException {
         receivedMessageHandler.close();
         log.info("Closing message bus: {}", configuration);
-        producerSession.close();
-        log.debug("Producer session closed.");
-        consumerSession.close();
-        log.debug("Consumer session closed.");
-        connection.close();
-        log.debug("Connection closed.");
+        try (connection; consumerSession; producerSession) {
+            log.debug("Closing producer session, consumer session and connection.");
+        }
     }
 
     @Override

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
@@ -26,6 +26,7 @@ import jakarta.jms.MessageListener;
 import org.bitrepository.bitrepositorymessages.DeleteFileRequest;
 import org.bitrepository.bitrepositorymessages.IdentifyPillarsForDeleteFileRequest;
 import org.bitrepository.bitrepositorymessages.IdentifyPillarsForDeleteFileResponse;
+import org.bitrepository.protocol.CoordinationLayerException;
 import org.bitrepository.protocol.ProtocolComponentFactory;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;
 import org.bitrepository.protocol.message.ExampleMessageFactory;
@@ -180,5 +181,41 @@ class ActiveMQMessageBusTest extends GeneralMessageBusTest {
         response.setStringProperty(ActiveMQMessageBus.MESSAGE_TO_KEY, "OtherComponent");
         rawMessagebus.sendMessage(settingsForTestClient.getCollectionDestination(), rq);
         collectionReceiver.waitForMessage(DeleteFileRequest.class);
+    }
+
+    @Test
+    @Tag("regressiontest")
+    final void closeReleasesJmsResourcesTest() throws Exception {
+        addDescription("Test that closing a message bus releases its JMS resources, so it can no longer " +
+                "be used to send messages afterwards.");
+        addStep("Create a dedicated message bus instance and close it",
+                "No exception should be thrown while closing.");
+        ActiveMQMessageBus dedicatedMessageBus = new ActiveMQMessageBus(settingsForTestClient, securityManager);
+        dedicatedMessageBus.close();
+
+        addStep("Attempt to send a message on the closed message bus",
+                "The send should fail, since the underlying JMS session and connection have been closed.");
+        IdentifyPillarsForDeleteFileRequest message =
+                ExampleMessageFactory.createMessage(IdentifyPillarsForDeleteFileRequest.class);
+        message.setDestination(settingsForTestClient.getCollectionDestination());
+        Assertions.assertThrows(CoordinationLayerException.class, () -> dedicatedMessageBus.sendMessage(message));
+    }
+
+    @Test
+    @Tag("regressiontest")
+    final void rawMessagebusCloseReleasesJmsResourcesTest() throws Exception {
+        addDescription("Test that closing a RawMessagebus releases its JMS resources, so it can no longer " +
+                "be used afterwards.");
+        addStep("Create a raw message bus instance and close it",
+                "No exception should be thrown while closing.");
+        RawMessagebus rawMessagebus = new RawMessagebus(
+                settingsForTestClient.getMessageBusConfiguration(),
+                securityManager);
+        rawMessagebus.close();
+
+        addStep("Attempt to create a producer on the closed raw message bus",
+                "The call should fail, since the underlying JMS session and connection have been closed.");
+        Assertions.assertThrows(CoordinationLayerException.class,
+                () -> rawMessagebus.getProducer(settingsForTestClient.getCollectionDestination()));
     }
 }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/ActiveMQMessageBusTest.java
@@ -194,7 +194,7 @@ class ActiveMQMessageBusTest extends GeneralMessageBusTest {
         dedicatedMessageBus.close();
 
         addStep("Attempt to send a message on the closed message bus",
-                "The send should fail, since the underlying JMS session and connection have been closed.");
+                "The send should fail since the underlying JMS session and connection have been closed.");
         IdentifyPillarsForDeleteFileRequest message =
                 ExampleMessageFactory.createMessage(IdentifyPillarsForDeleteFileRequest.class);
         message.setDestination(settingsForTestClient.getCollectionDestination());

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -58,15 +58,42 @@ public class RawMessagebus {
 
         var connectionFactory = ArtemisConnectionFactoryProvider.create(messageBusConfiguration);
         try {
-            connection = connectionFactory.createConnection();
-            connection.setExceptionListener(new MessageBusExceptionListener());
+            newConnection = connectionFactory.createConnection();
+            newConnection.setExceptionListener(new MessageBusExceptionListener());
 
-            producerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            consumerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            producerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            consumerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            connection = newConnection;
 
             connection.start();
         } catch (JMSException e) {
+            closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
+        }
+    }
+
+    /**
+     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
+     * failed initialisation without masking the original error.
+     */
+    private void closeQuietly(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (JMSException e) {
+                log.warn("Failed to close connection after initialisation failure", e);
+            }
+        }
+    }
+
+    /**
+     * Closes the producer session, consumer session and connection. Declared in reverse close order so
+     * try-with-resources closes the sessions before the connection, guaranteeing all are attempted even
+     * if one throws.
+     */
+    public void close() throws JMSException {
+        try (connection; consumerSession; producerSession) {
+            log.debug("Closing raw message bus connection.");
         }
     }
 

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -34,6 +34,7 @@ import org.bitrepository.common.JaxbHelper;
 import org.bitrepository.protocol.CoordinationLayerException;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;
 import org.bitrepository.protocol.activemq.ArtemisConnectionFactoryProvider;
+import org.bitrepository.protocol.activemq.JmsConnectionUtils;
 import org.bitrepository.protocol.security.SecurityManager;
 import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
 import org.slf4j.Logger;
@@ -68,31 +69,13 @@ public class RawMessagebus {
 
             connection.start();
         } catch (JMSException e) {
-            closeQuietly(newConnection);
+            JmsConnectionUtils.closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
     }
 
-    /**
-     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
-     * failed initialisation without masking the original error.
-     */
-    private void closeQuietly(Connection connection) {
-        if (connection != null) {
-            try {
-                connection.close();
-            } catch (JMSException e) {
-                log.warn("Failed to close connection after initialisation failure", e);
-            }
-        }
-    }
-
-    /**
-     * Closes the producer session, consumer session and connection. Declared in reverse close order so
-     * try-with-resources closes the sessions before the connection, guaranteeing all are attempted even
-     * if one throws.
-     */
     public void close() throws JMSException {
+//     Closes the producer session, consumer session and connection.
         try (connection; consumerSession; producerSession) {
             log.debug("Closing raw message bus connection.");
         }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -57,16 +57,44 @@ public class RawMessagebus {
         this.securityManager = securityManager;
 
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(messageBusConfiguration.getURL());
+        Connection newConnection = null;
         try {
-            connection = connectionFactory.createConnection();
-            connection.setExceptionListener(new MessageBusExceptionListener());
+            newConnection = connectionFactory.createConnection();
+            newConnection.setExceptionListener(new MessageBusExceptionListener());
 
-            producerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            consumerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            producerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            consumerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            connection = newConnection;
 
             connection.start();
         } catch (JMSException e) {
+            closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
+        }
+    }
+
+    /**
+     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
+     * failed initialisation without masking the original error.
+     */
+    private void closeQuietly(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (JMSException e) {
+                log.warn("Failed to close connection after initialisation failure", e);
+            }
+        }
+    }
+
+    /**
+     * Closes the producer session, consumer session and connection. Declared in reverse close order so
+     * try-with-resources closes the sessions before the connection, guaranteeing all are attempted even
+     * if one throws.
+     */
+    public void close() throws JMSException {
+        try (connection; consumerSession; producerSession) {
+            log.debug("Closing raw message bus connection.");
         }
     }
 

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -30,10 +30,11 @@ import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
-import org.bitrepository.protocol.activemq.ArtemisConnectionFactoryProvider;
 import org.bitrepository.common.JaxbHelper;
 import org.bitrepository.protocol.CoordinationLayerException;
 import org.bitrepository.protocol.activemq.ActiveMQMessageBus;
+import org.bitrepository.protocol.activemq.ArtemisConnectionFactoryProvider;
+import org.bitrepository.protocol.activemq.JmsConnectionUtils;
 import org.bitrepository.protocol.security.SecurityManager;
 import org.bitrepository.settings.repositorysettings.MessageBusConfiguration;
 import org.slf4j.Logger;
@@ -57,17 +58,18 @@ public class RawMessagebus {
         this.securityManager = securityManager;
 
         var connectionFactory = ArtemisConnectionFactoryProvider.create(messageBusConfiguration);
+        Connection connection = null;
         try {
-            newConnection = connectionFactory.createConnection();
-            newConnection.setExceptionListener(new MessageBusExceptionListener());
+            connection = connectionFactory.createConnection();
+            connection.setExceptionListener(new MessageBusExceptionListener());
 
-            producerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            consumerSession = newConnection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
-            connection = newConnection;
+            producerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            consumerSession = connection.createSession(TRANSACTED, Session.AUTO_ACKNOWLEDGE);
+            this.connection = connection;
 
             connection.start();
         } catch (JMSException e) {
-            JmsConnectionUtils.closeQuietly(newConnection);
+            JmsConnectionUtils.closeQuietly(connection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
     }

--- a/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
+++ b/bitrepository-core/src/test/java/org/bitrepository/protocol/bus/RawMessagebus.java
@@ -67,31 +67,13 @@ public class RawMessagebus {
 
             connection.start();
         } catch (JMSException e) {
-            closeQuietly(newConnection);
+            JmsConnectionUtils.closeQuietly(newConnection);
             throw new CoordinationLayerException("Unable to initialise connection to message bus", e);
         }
     }
 
-    /**
-     * Closes the connection, suppressing any JMSException, so it can be safely used for cleanup after a
-     * failed initialisation without masking the original error.
-     */
-    private void closeQuietly(Connection connection) {
-        if (connection != null) {
-            try {
-                connection.close();
-            } catch (JMSException e) {
-                log.warn("Failed to close connection after initialisation failure", e);
-            }
-        }
-    }
-
-    /**
-     * Closes the producer session, consumer session and connection. Declared in reverse close order so
-     * try-with-resources closes the sessions before the connection, guaranteeing all are attempted even
-     * if one throws.
-     */
     public void close() throws JMSException {
+//     Closes the producer session, consumer session and connection.
         try (connection; consumerSession; producerSession) {
             log.debug("Closing raw message bus connection.");
         }


### PR DESCRIPTION
 JVM now guarantees they're closed fully and safely — even if closing one resource throws, the others are still attempted, and the original exception isn't masked.