### PR TITLE
Set version number one place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ auditcontributerdb
 derby.log
 bitrepository.log
 bitrepository-reference-pillar/log
+.flattened-pom.xml

--- a/bitrepository-alarm-service/pom.xml
+++ b/bitrepository-alarm-service/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>

--- a/bitrepository-audit-trail-service/pom.xml
+++ b/bitrepository-audit-trail-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>bitrepository-parent</artifactId>
     <groupId>org.bitrepository.reference</groupId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>bitrepository-audit-trail-service</artifactId>

--- a/bitrepository-client/pom.xml
+++ b/bitrepository-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>bitrepository-parent</artifactId>
     <groupId>org.bitrepository.reference</groupId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/bitrepository-core/pom.xml
+++ b/bitrepository-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>bitrepository-core</artifactId>
   <name>Bitrepository Core</name>

--- a/bitrepository-integration/pom.xml
+++ b/bitrepository-integration/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>bitrepository-integration</artifactId>

--- a/bitrepository-integrity-service/pom.xml
+++ b/bitrepository-integrity-service/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bitrepository-monitoring-service/pom.xml
+++ b/bitrepository-monitoring-service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>bitrepository-monitoring-service</artifactId>
   <packaging>war</packaging>

--- a/bitrepository-reference-pillar/pom.xml
+++ b/bitrepository-reference-pillar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bitrepository.reference</groupId>
         <artifactId>bitrepository-parent</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>bitrepository-reference-pillar</artifactId>

--- a/bitrepository-reference-settings/pom.xml
+++ b/bitrepository-reference-settings/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>bitrepository-reference-settings</artifactId>
   <name>Bitrepository Reference Settings</name>

--- a/bitrepository-service/pom.xml
+++ b/bitrepository-service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>bitrepository-parent</artifactId>
     <groupId>org.bitrepository.reference</groupId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/bitrepository-webclient/pom.xml
+++ b/bitrepository-webclient/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>bitrepository-webclient</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bitrepository.reference</groupId>
     <artifactId>bitrepository-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <parent>
         <groupId>org.sbforge</groupId>
@@ -405,6 +405,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.3</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -581,6 +606,7 @@
     </profiles>
 
     <properties>
+        <revision>1.12-SNAPSHOT</revision>
         <!-- Specify java version here, to support forbiddenapis plugin -->
         <maven.compiler.release>21</maven.compiler.release>
         <api.check.phase>process-classes</api.check.phase> <!-- forbidden-apis dislikes TestValidationUtils #validateUtilityClass -->


### PR DESCRIPTION
Using flatten-maven-plugin the version number can be placed one place in the parent pom and then referenced in the sub-poms